### PR TITLE
fix: 修复集成矿物处理厂宝石类矿物未乘crushedAmount的问题

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/recipe/OreRecipeHandlerMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/recipe/OreRecipeHandlerMixin.java
@@ -201,9 +201,9 @@ public abstract class OreRecipeHandlerMixin {
 
             // 4 研磨-洗矿-筛选-离心
             if (material.hasProperty(PropertyKey.GEM)) {
-                ItemStack exquisiteStack = ChemicalHelper.get(gemExquisite, material);
-                ItemStack flawlessStack = ChemicalHelper.get(gemFlawless, material);
-                ItemStack gemStack = ChemicalHelper.get(gem, material);
+                ItemStack exquisiteStack = ChemicalHelper.get(gemExquisite, material, crushedAmount);
+                ItemStack flawlessStack = ChemicalHelper.get(gemFlawless, material, crushedAmount);
+                ItemStack gemStack = ChemicalHelper.get(gem, material, crushedAmount);
                 if (material.hasFlag(HIGH_SIFTER_OUTPUT)) {
                     GTRecipeBuilder opBuilder4 = INTEGRATED_ORE_PROCESSOR
                             .recipeBuilder("integrated_ore_processor_4_" + material.getName())
@@ -308,9 +308,9 @@ public abstract class OreRecipeHandlerMixin {
 
                 // 7 研磨-浸洗-筛选-离心
                 if (material.hasProperty(PropertyKey.GEM)) {
-                    ItemStack exquisiteStack = ChemicalHelper.get(gemExquisite, material);
-                    ItemStack flawlessStack = ChemicalHelper.get(gemFlawless, material);
-                    ItemStack gemStack = ChemicalHelper.get(gem, material);
+                    ItemStack exquisiteStack = ChemicalHelper.get(gemExquisite, material, crushedAmount);
+                    ItemStack flawlessStack = ChemicalHelper.get(gemFlawless, material, crushedAmount);
+                    ItemStack gemStack = ChemicalHelper.get(gem, material, crushedAmount);
                     if (material.hasFlag(HIGH_SIFTER_OUTPUT)) {
                         GTRecipeBuilder opBuilder7 = INTEGRATED_ORE_PROCESSOR
                                 .recipeBuilder("integrated_ore_processor_7_" + material.getName())
@@ -503,9 +503,9 @@ public abstract class OreRecipeHandlerMixin {
 
             // 4 研磨-洗矿-筛选-离心
             if (material.hasProperty(PropertyKey.GEM)) {
-                ItemStack exquisiteStack = ChemicalHelper.get(gemExquisite, material);
-                ItemStack flawlessStack = ChemicalHelper.get(gemFlawless, material);
-                ItemStack gemStack = ChemicalHelper.get(gem, material);
+                ItemStack exquisiteStack = ChemicalHelper.get(gemExquisite, material, crushedAmount);
+                ItemStack flawlessStack = ChemicalHelper.get(gemFlawless, material, crushedAmount);
+                ItemStack gemStack = ChemicalHelper.get(gem, material, crushedAmount);
                 if (material.hasFlag(HIGH_SIFTER_OUTPUT)) {
                     GTRecipeBuilder opBuilder4 = INTEGRATED_ORE_PROCESSOR
                             .recipeBuilder("raw_integrated_ore_processor_4_" + material.getName())
@@ -586,9 +586,9 @@ public abstract class OreRecipeHandlerMixin {
 
                 // 7 研磨-浸洗-筛选-离心
                 if (material.hasProperty(PropertyKey.GEM)) {
-                    ItemStack exquisiteStack = ChemicalHelper.get(gemExquisite, material);
-                    ItemStack flawlessStack = ChemicalHelper.get(gemFlawless, material);
-                    ItemStack gemStack = ChemicalHelper.get(gem, material);
+                    ItemStack exquisiteStack = ChemicalHelper.get(gemExquisite, material, crushedAmount);
+                    ItemStack flawlessStack = ChemicalHelper.get(gemFlawless, material, crushedAmount);
+                    ItemStack gemStack = ChemicalHelper.get(gem, material, crushedAmount);
                     if (material.hasFlag(HIGH_SIFTER_OUTPUT)) {
                         GTRecipeBuilder opBuilder7 = INTEGRATED_ORE_PROCESSOR
                                 .recipeBuilder("raw_integrated_ore_processor_7_" + material.getName())


### PR DESCRIPTION
集成矿物处理的4号和7号编程电路配方未正确将宝石乘以crushedAmount
前
<img width="351" height="243" alt="image" src="https://github.com/user-attachments/assets/4f9d2c16-6921-4d86-9236-487dde7a09f8" />
后
<img width="337" height="204" alt="image" src="https://github.com/user-attachments/assets/c9d440d5-9af7-43b5-ab7e-a4d545946b85" />