### PR TITLE
修复巨型输入总线/总成接收 AE 样板编程电路堵塞问题

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtmt/HugeBusPartMachineMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtmt/HugeBusPartMachineMixin.java
@@ -1,13 +1,18 @@
 package org.gtlcore.gtlcore.mixin.gtmt;
 
 import org.gtlcore.gtlcore.api.machine.trait.IRecipeCapabilityMachine;
+import org.gtlcore.gtlcore.api.machine.trait.NotifiableCircuitItemStackHandler;
 
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.multiblock.part.TieredIOPartMachine;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
+import com.gregtechceu.gtceu.common.item.IntCircuitBehaviour;
 
+import com.hepdd.gtmthings.api.misc.UnlimitedItemStackTransfer;
 import com.hepdd.gtmthings.common.block.machine.multiblock.part.HugeBusPartMachine;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -20,9 +25,28 @@ public abstract class HugeBusPartMachineMixin extends TieredIOPartMachine {
         super(holder, tier, io);
     }
 
+    @Shadow(remap = false)
+    protected abstract int getInventorySize();
+
     @Inject(method = "getInventorySize", at = @At("RETURN"), remap = false, cancellable = true)
     protected void getInventorySize(CallbackInfoReturnable<Integer> cir) {
         cir.setReturnValue(cir.getReturnValue() - 1);
+    }
+
+    @Inject(method = "createInventory", at = @At("HEAD"), remap = false, cancellable = true)
+    protected void createInventory(Object[] args, CallbackInfoReturnable<NotifiableItemStackHandler> cir) {
+        if (io == IO.IN) {
+            cir.setReturnValue(new NotifiableItemStackHandler(this, getInventorySize(), IO.IN, IO.IN,
+                    UnlimitedItemStackTransfer::new)
+                    .setFilter(itemStack -> !IntCircuitBehaviour.isIntegratedCircuit(itemStack)));
+        }
+    }
+
+    @Inject(method = "createCircuitItemHandler", at = @At("HEAD"), remap = false, cancellable = true)
+    protected void createCircuitItemHandler(Object[] args, CallbackInfoReturnable<NotifiableItemStackHandler> cir) {
+        if (args.length > 0 && args[0] instanceof IO io && io == IO.IN) {
+            cir.setReturnValue(new NotifiableCircuitItemStackHandler(this));
+        }
     }
 
     @Inject(method = "setDistinct", at = @At("RETURN"), remap = false)


### PR DESCRIPTION
## 问题
GTMThings 的巨型输入总线和巨型输入总成在接收 AE 样板供应器推送的编程电路时，会将其作为普通物品放入巨型物品库存，导致库存堵塞。

## 修复
在 `HugeBusPartMachineMixin` 中补齐输入侧处理逻辑：

- 输入侧普通巨型物品库存拒收 GT 编程电路
- 输入侧电路槽复用 `NotifiableCircuitItemStackHandler`
- 保留 `UnlimitedItemStackTransfer::new`，避免破坏巨型库存容量
- 输出侧逻辑保持不变

## 验证
- `spotlessCheck` 通过
- `compileJava` 通过
- `build` 通过
- 已在整合包内验证修复有效