### PR TITLE
修复 AE 样板输入下巨型仓室的电路、退回与阻挡模式问题

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/api/machine/trait/NotifiableCircuitItemStackHandler.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/machine/trait/NotifiableCircuitItemStackHandler.java
@@ -25,7 +25,9 @@ public class NotifiableCircuitItemStackHandler extends NotifiableItemStackHandle
     @Override
     public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate, boolean notifyChange) {
         if (GTItems.INTEGRATED_CIRCUIT.isIn(stack)) {
-            storage.setStackInSlot(slot, stack);
+            if (!simulate) {
+                storage.setStackInSlot(slot, stack.copyWithCount(1));
+            }
             return ItemStack.EMPTY;
         }
         return stack;

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtmt/HugeBusPartMachineMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtmt/HugeBusPartMachineMixin.java
@@ -37,8 +37,13 @@ public abstract class HugeBusPartMachineMixin extends TieredIOPartMachine {
     protected void createInventory(Object[] args, CallbackInfoReturnable<NotifiableItemStackHandler> cir) {
         if (io == IO.IN) {
             cir.setReturnValue(new NotifiableItemStackHandler(this, getInventorySize(), IO.IN, IO.IN,
-                    UnlimitedItemStackTransfer::new)
-                    .setFilter(itemStack -> !IntCircuitBehaviour.isIntegratedCircuit(itemStack)));
+                    UnlimitedItemStackTransfer::new) {
+
+                @Override
+                public boolean canCapOutput() {
+                    return true;
+                }
+            }.setFilter(itemStack -> !IntCircuitBehaviour.isIntegratedCircuit(itemStack)));
         }
     }
 

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtmt/trait/CatalystFluidStackHandlerMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtmt/trait/CatalystFluidStackHandlerMixin.java
@@ -22,6 +22,9 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
 
@@ -33,6 +36,11 @@ public abstract class CatalystFluidStackHandlerMixin extends NotifiableFluidTank
 
     public CatalystFluidStackHandlerMixin(MetaMachine machine, int slots, long capacity, IO io, IO capabilityIO) {
         super(machine, slots, capacity, io, capabilityIO);
+    }
+
+    @Inject(method = "<init>(Lcom/gregtechceu/gtceu/api/machine/MetaMachine;IJLcom/gregtechceu/gtceu/api/capability/recipe/IO;Lcom/gregtechceu/gtceu/api/capability/recipe/IO;)V", at = @At("RETURN"), remap = false)
+    private void gTLCore$disableExternalCapability(MetaMachine machine, int slots, long capacity, IO io, IO capabilityIO, CallbackInfo ci) {
+        setCapabilityValidator(side -> false);
     }
 
     /**

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtmt/trait/CatalystItemStackHandlerMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtmt/trait/CatalystItemStackHandlerMixin.java
@@ -22,6 +22,9 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
 import java.util.function.Function;
@@ -34,6 +37,11 @@ public abstract class CatalystItemStackHandlerMixin extends NotifiableItemStackH
 
     public CatalystItemStackHandlerMixin(MetaMachine machine, int slots, @NotNull IO handlerIO, @NotNull IO capabilityIO, Function<Integer, ItemStackTransfer> transferFactory) {
         super(machine, slots, handlerIO, capabilityIO, transferFactory);
+    }
+
+    @Inject(method = "<init>(Lcom/gregtechceu/gtceu/api/machine/MetaMachine;ILcom/gregtechceu/gtceu/api/capability/recipe/IO;Lcom/gregtechceu/gtceu/api/capability/recipe/IO;)V", at = @At("RETURN"), remap = false)
+    private void gTLCore$disableExternalCapability(MetaMachine machine, int slots, IO handlerIO, IO capabilityIO, CallbackInfo ci) {
+        setCapabilityValidator(side -> false);
     }
 
     /**


### PR DESCRIPTION
## 问题

在 AE 样板供应器向 GT/GTMThings 机器发送处理样板输入时，存在几类和编程电路、巨型输入仓室、阻挡模式相关的问题：

1. 编程电路作为样板输入进入机器电路槽时，模拟插入和真实插入可能导致电路数量堆叠。
2. 巨型输入总线/总成的一键退回按钮可以退回流体，但普通固体输入无法正常退回。
3. 巨型输入总成带共享催化剂槽时，AE 阻挡模式会通过外部 capability 扫描到催化剂槽内容，将其误判为普通输入，导致普通输入槽为空时仍拒绝发送材料，AE 合成卡死。

## 修复

本 PR 做了以下调整：

- 让 `NotifiableCircuitItemStackHandler` 在模拟插入时保持无副作用。
- 编程电路真实插入电路槽时只保留 1 个，作为电路编号状态使用，避免堆叠。
- 允许巨型输入仓室的普通输入库存被外部抽出，用于支持一键退回普通固体输入。
- 保持巨型输入仓室普通输入库存拒收 GT 编程电路，避免电路进入普通物品槽。
- 隐藏 GTMThings 共享固体/流体催化剂槽的外部 capability，避免 AE 阻挡模式把催化剂槽内容当作普通输入。
- 保留催化剂槽的内部配方匹配和 GUI 手动放入/取出行为。

## 验证

- `./gradlew spotlessCheck compileJava`
- `./gradlew build`
- 已在整合包内实际游玩验证：
  - AE 样板电路不会堆叠。
  - 巨型输入总成普通固体可以一键退回。
  - 带催化剂槽的化学反应输入总成在 AE 阻挡模式下不再卡合成。
