### PR TITLE
优化无线 ME 网络 Jade 连接状态显示

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAeNetworkRuntime.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAeNetworkRuntime.java
@@ -306,6 +306,43 @@ public final class WirelessAeNetworkRuntime {
         return frequency.toString().substring(0, 8);
     }
 
+    public static boolean isMemberConnected(MinecraftServer server, UUID frequency, WirelessAeSavedData.MemberKey member) {
+        Map<WirelessAeSavedData.MemberKey, IGridConnection> frequencyConnections = CONNECTIONS.get(frequency);
+        if (hasStoredConnection(frequencyConnections, member)) {
+            return true;
+        }
+
+        WirelessNetworkCoreBlockEntity core = getLoadedCore(server, frequency);
+        if (core == null) {
+            return false;
+        }
+
+        IGridNode bridgeNode = findBridgeNode(core);
+        IGridNode targetNode = findTargetNode(server, member);
+        return bridgeNode != null && targetNode != null && (areConnected(bridgeNode, targetNode) || isSameGrid(bridgeNode, targetNode));
+    }
+
+    public static UUID findWiredNetworkFrequency(MinecraftServer server, WirelessAeSavedData.MemberKey member) {
+        IGridNode targetNode = findTargetNode(server, member);
+        if (targetNode == null) {
+            return null;
+        }
+
+        WirelessAeSavedData data = WirelessAeSavedData.get(server);
+        for (WirelessAeSavedData.NetworkInfo network : data.getNetworkInfo()) {
+            WirelessNetworkCoreBlockEntity core = getLoadedCore(server, network.frequency());
+            if (core == null) {
+                continue;
+            }
+
+            IGridNode bridgeNode = findBridgeNode(core);
+            if (bridgeNode != null && isSameGrid(bridgeNode, targetNode)) {
+                return network.frequency();
+            }
+        }
+        return null;
+    }
+
     private static void clearMemberBinding(ServerLevel level, BlockPos pos) {
         GlobalPos member = GlobalPos.of(level.dimension(), pos);
         WirelessAeSavedData data = WirelessAeSavedData.get(level.getServer());
@@ -427,6 +464,25 @@ public final class WirelessAeNetworkRuntime {
                     error);
             return ConnectionResult.FAILED;
         }
+    }
+
+    private static boolean hasStoredConnection(Map<WirelessAeSavedData.MemberKey, IGridConnection> frequencyConnections,
+                                               WirelessAeSavedData.MemberKey member) {
+        if (frequencyConnections == null) {
+            return false;
+        }
+        if (frequencyConnections.get(member) != null) {
+            return true;
+        }
+        if (member.side() != null) {
+            return frequencyConnections.get(new WirelessAeSavedData.MemberKey(member.pos(), null)) != null;
+        }
+        for (Map.Entry<WirelessAeSavedData.MemberKey, IGridConnection> entry : frequencyConnections.entrySet()) {
+            if (entry.getValue() != null && entry.getKey().pos().equals(member.pos())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean isUsableBridgeNode(IGridNode coreNode, IGridNode bridgeNode) {

--- a/src/main/java/org/gtlcore/gtlcore/integration/jade/GTLJadePlugin.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jade/GTLJadePlugin.java
@@ -26,6 +26,7 @@ public class GTLJadePlugin implements IWailaPlugin {
         registration.registerBlockDataProvider(new MEPatternBufferProvider(), BlockEntity.class);
         registration.registerBlockDataProvider(new MEPatternBufferProxyProvider(), BlockEntity.class);
         registration.registerBlockDataProvider(new MEMAIOProvider(), BlockEntity.class);
+        registration.registerBlockDataProvider(new WirelessAeNetworkProvider(), BlockEntity.class);
     }
 
     @Override
@@ -35,5 +36,6 @@ public class GTLJadePlugin implements IWailaPlugin {
         registration.registerBlockComponent(new MEPatternBufferProvider(), Block.class);
         registration.registerBlockComponent(new MEPatternBufferProxyProvider(), Block.class);
         registration.registerBlockComponent(new MEMAIOProvider(), Block.class);
+        registration.registerBlockComponent(new WirelessAeNetworkProvider(), Block.class);
     }
 }

--- a/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/WirelessAeNetworkProvider.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/WirelessAeNetworkProvider.java
@@ -1,0 +1,128 @@
+package org.gtlcore.gtlcore.integration.jade.provider;
+
+import org.gtlcore.gtlcore.GTLCore;
+import org.gtlcore.gtlcore.integration.ae2.wireless.WirelessAeNetworkRuntime;
+import org.gtlcore.gtlcore.integration.ae2.wireless.WirelessAeSavedData;
+import org.gtlcore.gtlcore.integration.ae2.wireless.WirelessNetworkCoreBlockEntity;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.IServerDataProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+import java.util.UUID;
+
+public class WirelessAeNetworkProvider implements IBlockComponentProvider, IServerDataProvider<BlockAccessor> {
+
+    private static final ResourceLocation UID = GTLCore.id("wireless_ae_network_provider");
+    private static final String TAG_PRESENT = "gtlcore_wireless_ae";
+    private static final String TAG_CORE = "wireless_ae_core";
+    private static final String TAG_BOUND = "wireless_ae_bound";
+    private static final String TAG_CONNECTED = "wireless_ae_connected";
+    private static final String TAG_NETWORK_NAME = "wireless_ae_network_name";
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor blockAccessor, IPluginConfig config) {
+        CompoundTag serverData = blockAccessor.getServerData();
+        if (!serverData.getBoolean(TAG_PRESENT)) {
+            return;
+        }
+
+        boolean connected = serverData.getBoolean(TAG_CONNECTED);
+        if (serverData.getBoolean(TAG_CORE)) {
+            tooltip.add(Component.translatable(connected ?
+                    "tooltip.gtlcore.wireless_ae.core_connected" :
+                    "tooltip.gtlcore.wireless_ae.core_disconnected",
+                    serverData.getString(TAG_NETWORK_NAME))
+                    .withStyle(connected ? ChatFormatting.GREEN : ChatFormatting.YELLOW));
+            return;
+        }
+
+        if (!serverData.getBoolean(TAG_BOUND)) {
+            tooltip.add(Component.translatable("tooltip.gtlcore.wireless_ae.target_unbound")
+                    .withStyle(ChatFormatting.GRAY));
+            return;
+        }
+
+        tooltip.add(Component.translatable(connected ?
+                "tooltip.gtlcore.wireless_ae.target_connected" :
+                "tooltip.gtlcore.wireless_ae.target_waiting",
+                serverData.getString(TAG_NETWORK_NAME))
+                .withStyle(connected ? ChatFormatting.GREEN : ChatFormatting.YELLOW));
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, BlockAccessor blockAccessor) {
+        Level level = blockAccessor.getLevel();
+        if (!(level instanceof ServerLevel serverLevel)) {
+            return;
+        }
+
+        BlockEntity blockEntity = blockAccessor.getBlockEntity();
+        if (blockEntity instanceof WirelessNetworkCoreBlockEntity core) {
+            appendCoreData(data, serverLevel, core);
+            return;
+        }
+
+        BlockPos targetPos = WirelessAeNetworkRuntime.resolveWirelessTargetPos(serverLevel, blockAccessor.getPosition());
+        if (!WirelessAeNetworkRuntime.isWirelessMeTarget(serverLevel, targetPos)) {
+            return;
+        }
+
+        BlockHitResult hitResult = blockAccessor.getHitResult();
+        Vec3 hitLocation = hitResult == null ? null : hitResult.getLocation();
+        WirelessAeSavedData.MemberKey target = WirelessAeNetworkRuntime.resolveWirelessTarget(
+                serverLevel,
+                blockAccessor.getPosition(),
+                blockAccessor.getSide(),
+                hitLocation);
+        WirelessAeSavedData savedData = WirelessAeSavedData.get(serverLevel.getServer());
+        UUID frequency = savedData.getMemberNetwork(target);
+        boolean connected = false;
+
+        if (frequency != null) {
+            connected = WirelessAeNetworkRuntime.isMemberConnected(serverLevel.getServer(), frequency, target);
+        } else {
+            frequency = WirelessAeNetworkRuntime.findWiredNetworkFrequency(serverLevel.getServer(), target);
+            connected = frequency != null;
+        }
+
+        data.putBoolean(TAG_PRESENT, true);
+        data.putBoolean(TAG_CORE, false);
+        data.putBoolean(TAG_BOUND, frequency != null);
+        if (frequency == null) {
+            data.putBoolean(TAG_CONNECTED, false);
+            return;
+        }
+
+        data.putBoolean(TAG_CONNECTED, connected);
+        data.putString(TAG_NETWORK_NAME, savedData.getNetworkName(frequency));
+    }
+
+    private static void appendCoreData(CompoundTag data, ServerLevel level, WirelessNetworkCoreBlockEntity core) {
+        WirelessAeSavedData savedData = WirelessAeSavedData.get(level.getServer());
+        UUID frequency = core.getFrequency();
+        data.putBoolean(TAG_PRESENT, true);
+        data.putBoolean(TAG_CORE, true);
+        data.putBoolean(TAG_BOUND, true);
+        data.putBoolean(TAG_CONNECTED, core.isLinkedToAeNetwork());
+        data.putString(TAG_NETWORK_NAME, savedData.getNetworkName(frequency));
+    }
+
+    @Override
+    public ResourceLocation getUid() {
+        return UID;
+    }
+}

--- a/src/main/resources/assets/gtlcore/lang/en_us.json
+++ b/src/main/resources/assets/gtlcore/lang/en_us.json
@@ -111,6 +111,7 @@
   "config.gtlcore.option.sendUpdateMessages": "Enable Update Notifications",
   "config.jade.plugin_gtlcore.tick_time_provider": "[GTLCore] Tick Time",
   "config.jade.plugin_gtlcore.wireless_data_hatch_provider": "Wireless Data Hatch",
+  "config.jade.plugin_gtlcore.wireless_ae_network_provider": "Wireless ME Network",
   "gtlcore.condition.gravity": "Requires High Gravity Environment",
   "gtlcore.condition.zero_gravity": "Requires Zero Gravity Environment",
   "gtlcore.gui.filter_config.title": "Filter Configuration",
@@ -431,5 +432,10 @@
   "message.gtlcore.wireless_target.missing_core": "That wireless ME network core no longer exists.",
   "message.gtlcore.wireless_target.invalid_target": "This block does not expose an ME network node.",
   "message.gtlcore.wireless_target.linked_target": "Linked ME hatch to the wireless ME network (%s).",
-  "message.gtlcore.wireless_target.linked_target_pending": "Recorded this ME block and waiting for the wireless ME network connection (%s)."
+  "message.gtlcore.wireless_target.linked_target_pending": "Recorded this ME block and waiting for the wireless ME network connection (%s).",
+  "tooltip.gtlcore.wireless_ae.core_connected": "Wireless ME network: %s (attached to an ME network)",
+  "tooltip.gtlcore.wireless_ae.core_disconnected": "Wireless ME network: %s (not attached to an ME network)",
+  "tooltip.gtlcore.wireless_ae.target_unbound": "Wireless ME network: not connected",
+  "tooltip.gtlcore.wireless_ae.target_connected": "Wireless ME network: %s (connected)",
+  "tooltip.gtlcore.wireless_ae.target_waiting": "Wireless ME network: %s (waiting for connection)"
 }

--- a/src/main/resources/assets/gtlcore/lang/zh_cn.json
+++ b/src/main/resources/assets/gtlcore/lang/zh_cn.json
@@ -111,6 +111,7 @@
   "config.gtlcore.option.sendUpdateMessages": "是否启用更新提醒",
   "config.jade.plugin_gtlcore.tick_time_provider": "[GTLCore] Tick时间",
   "config.jade.plugin_gtlcore.wireless_data_hatch_provider": "无线数据仓",
+  "config.jade.plugin_gtlcore.wireless_ae_network_provider": "无线 ME 网络",
   "gtlcore.condition.gravity": "需要强重力环境",
   "gtlcore.condition.zero_gravity": "需要无重力环境",
   "gtlcore.gui.filter_config.title": "过滤设置",
@@ -431,5 +432,10 @@
   "message.gtlcore.wireless_target.missing_core": "这个无线 ME 网络核心已经不存在。",
   "message.gtlcore.wireless_target.invalid_target": "这个方块没有暴露可连接的 ME 网络节点。",
   "message.gtlcore.wireless_target.linked_target": "已将 ME 仓室接入无线 ME 网络（%s）。",
-  "message.gtlcore.wireless_target.linked_target_pending": "已记录这个 ME 方块，等待无线 ME 网络连接（%s）。"
+  "message.gtlcore.wireless_target.linked_target_pending": "已记录这个 ME 方块，等待无线 ME 网络连接（%s）。",
+  "tooltip.gtlcore.wireless_ae.core_connected": "无线 ME 网络：%s（已接入 ME 网络）",
+  "tooltip.gtlcore.wireless_ae.core_disconnected": "无线 ME 网络：%s（未接入 ME 网络）",
+  "tooltip.gtlcore.wireless_ae.target_unbound": "无线 ME 网络：未连接",
+  "tooltip.gtlcore.wireless_ae.target_connected": "无线 ME 网络：%s（已连接）",
+  "tooltip.gtlcore.wireless_ae.target_waiting": "无线 ME 网络：%s（等待连接）"
 }


### PR DESCRIPTION
## 修改内容

- 为无线 ME 网络添加 Jade 显示适配，支持显示无线 ME 网络核心和目标 ME 方块的连接状态。
- 支持通过线缆接入同一个 ME 网络时，识别该 ME 网络中已连接的无线 ME 网络核心并显示连接信息。