### PR TITLE
修复无线 ME 网络连接状态显示

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/client/ae2/wireless/WirelessAeScreenHooks.java
+++ b/src/main/java/org/gtlcore/gtlcore/client/ae2/wireless/WirelessAeScreenHooks.java
@@ -350,6 +350,7 @@ final class WirelessAeScreenHooks {
         int contentY = y + FANCY_HEADER_HEIGHT + 8;
         int contentWidth = width - (PANEL_MARGIN + 6) * 2;
         WirelessAePackets.TargetNetworkEntry connected = getConnectedEntry();
+        WirelessAePackets.TargetNetworkEntry disconnectable = getDisconnectableEntry();
 
         WirelessAeStyle.drawStatusLight(graphics, contentX, contentY, connected != null);
         WirelessAeStyle.drawTrimmedString(
@@ -386,17 +387,18 @@ final class WirelessAeScreenHooks {
             return;
         }
 
-        int bottomReserve = connected == null ? 8 : 36;
+        int bottomReserve = disconnectable == null ? 8 : 36;
         int maxRows = Math.max(1, (y + height - bottomReserve - listY) / NETWORK_ROW_HEIGHT);
         int rows = Math.min(embeddedEntries.size(), maxRows);
+        boolean lockedByCableConnection = isLockedByCableConnection();
         for (int i = 0; i < rows; i++) {
             WirelessAePackets.TargetNetworkEntry entry = embeddedEntries.get(i);
             int rowY = listY + i * NETWORK_ROW_HEIGHT;
-            boolean hovered = isInsideRect(mouseX, mouseY, contentX, rowY, contentWidth, 20);
+            boolean hovered = !lockedByCableConnection && !entry.connected() && isInsideRect(mouseX, mouseY, contentX, rowY, contentWidth, 20);
             drawNetworkRow(graphics, contentX, rowY, contentWidth, entry, hovered);
         }
 
-        if (connected != null) {
+        if (disconnectable != null) {
             int disconnectY = y + height - 30;
             WirelessAeStyle.drawSeparator(graphics, contentX, disconnectY - 5, contentWidth);
             boolean hovered = isInsideRect(mouseX, mouseY, contentX, disconnectY, contentWidth, 20);
@@ -446,21 +448,26 @@ final class WirelessAeScreenHooks {
         int contentWidth = width - (PANEL_MARGIN + 6) * 2;
         int listY = contentY + 18;
         WirelessAePackets.TargetNetworkEntry connected = getConnectedEntry();
-        int bottomReserve = connected == null ? 8 : 36;
+        WirelessAePackets.TargetNetworkEntry disconnectable = getDisconnectableEntry();
+        int bottomReserve = disconnectable == null ? 8 : 36;
         int maxRows = Math.max(1, (y + height - bottomReserve - listY) / NETWORK_ROW_HEIGHT);
         int rows = Math.min(embeddedEntries.size(), maxRows);
+        boolean lockedByCableConnection = isLockedByCableConnection();
         for (int i = 0; i < rows; i++) {
             int rowY = listY + i * NETWORK_ROW_HEIGHT;
             if (isInsideRect(mouseX, mouseY, contentX, rowY, contentWidth, 20)) {
+                if (lockedByCableConnection) {
+                    return;
+                }
                 connectEmbeddedEntry(targetPos, embeddedEntries.get(i));
                 return;
             }
         }
 
-        if (connected != null) {
+        if (disconnectable != null) {
             int disconnectY = y + height - 30;
             if (isInsideRect(mouseX, mouseY, contentX, disconnectY, contentWidth, 20)) {
-                disconnectEmbeddedEntry(targetPos, connected);
+                disconnectEmbeddedEntry(targetPos, disconnectable);
             }
         }
     }
@@ -499,6 +506,7 @@ final class WirelessAeScreenHooks {
             updated.add(new WirelessAePackets.TargetNetworkEntry(
                     entry.frequency(),
                     entry.name(),
+                    entry.frequency().equals(frequency),
                     entry.frequency().equals(frequency)));
         }
         embeddedEntries = List.copyOf(updated);
@@ -517,6 +525,19 @@ final class WirelessAeScreenHooks {
             }
         }
         return null;
+    }
+
+    private static WirelessAePackets.TargetNetworkEntry getDisconnectableEntry() {
+        for (WirelessAePackets.TargetNetworkEntry entry : embeddedEntries) {
+            if (entry.disconnectable()) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isLockedByCableConnection() {
+        return getConnectedEntry() != null && getDisconnectableEntry() == null;
     }
 
     private static boolean isInsideRect(double mouseX, double mouseY, int x, int y, int width, int height) {

--- a/src/main/java/org/gtlcore/gtlcore/client/ae2/wireless/WirelessAeTargetScreen.java
+++ b/src/main/java/org/gtlcore/gtlcore/client/ae2/wireless/WirelessAeTargetScreen.java
@@ -24,7 +24,7 @@ public class WirelessAeTargetScreen extends AbstractContainerScreen<WirelessAeTa
         this.imageWidth = 248;
         int rows = Math.max(1, menu.getNetworks().size());
         this.imageHeight = Math.max(128,
-                LIST_Y + 8 + rows * ROW_HEIGHT + (getConnectedEntry() == null ? 0 : DISCONNECT_GAP + BUTTON_HEIGHT) + 14);
+                LIST_Y + 8 + rows * ROW_HEIGHT + (getDisconnectableEntry() == null ? 0 : DISCONNECT_GAP + BUTTON_HEIGHT) + 14);
     }
 
     @Override
@@ -38,8 +38,12 @@ public class WirelessAeTargetScreen extends AbstractContainerScreen<WirelessAeTa
                         new WirelessAePackets.OpenNormalTargetMenuPacket(this.menu.getOriginPos()))));
 
         int y = this.topPos + LIST_Y;
+        boolean lockedByCableConnection = isLockedByCableConnection();
         for (WirelessAeTargetMenu.Entry entry : this.menu.getNetworks()) {
             Button.OnPress onPress = button -> {
+                if (entry.connected() || lockedByCableConnection) {
+                    return;
+                }
                 WirelessAePackets.CHANNEL.sendToServer(
                         new WirelessAePackets.ConnectTargetPacket(
                                 this.menu.getTargetPos(),
@@ -60,8 +64,8 @@ public class WirelessAeTargetScreen extends AbstractContainerScreen<WirelessAeTa
             y += ROW_HEIGHT;
         }
 
-        WirelessAeTargetMenu.Entry connectedEntry = getConnectedEntry();
-        if (connectedEntry != null) {
+        WirelessAeTargetMenu.Entry disconnectableEntry = getDisconnectableEntry();
+        if (disconnectableEntry != null) {
             y += DISCONNECT_GAP;
             this.addRenderableWidget(WirelessAeStyle.warningButton(
                     this.leftPos + CONTENT_X,
@@ -75,7 +79,7 @@ public class WirelessAeTargetScreen extends AbstractContainerScreen<WirelessAeTa
                                         this.menu.getTargetPos(),
                                         this.menu.getTargetSide(),
                                         null,
-                                        connectedEntry.frequency(),
+                                        disconnectableEntry.frequency(),
                                         true));
                         this.onClose();
                     }));
@@ -98,7 +102,7 @@ public class WirelessAeTargetScreen extends AbstractContainerScreen<WirelessAeTa
                 this.topPos + 26,
                 this.imageWidth - 20,
                 this.imageHeight - 38);
-        if (getConnectedEntry() != null) {
+        if (getDisconnectableEntry() != null) {
             int rows = Math.max(1, this.menu.getNetworks().size());
             WirelessAeStyle.drawSeparator(
                     graphics,
@@ -141,5 +145,18 @@ public class WirelessAeTargetScreen extends AbstractContainerScreen<WirelessAeTa
             }
         }
         return null;
+    }
+
+    private WirelessAeTargetMenu.Entry getDisconnectableEntry() {
+        for (WirelessAeTargetMenu.Entry entry : this.menu.getNetworks()) {
+            if (entry.disconnectable()) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private boolean isLockedByCableConnection() {
+        return getConnectedEntry() != null && getDisconnectableEntry() == null;
     }
 }

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAeNetworkRuntime.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAeNetworkRuntime.java
@@ -322,6 +322,20 @@ public final class WirelessAeNetworkRuntime {
         return bridgeNode != null && targetNode != null && (areConnected(bridgeNode, targetNode) || isSameGrid(bridgeNode, targetNode));
     }
 
+    public static boolean hasWirelessConnection(UUID frequency, WirelessAeSavedData.MemberKey member) {
+        return hasStoredConnection(CONNECTIONS.get(frequency), member);
+    }
+
+    public static UUID findConnectedNetworkFrequency(MinecraftServer server, WirelessAeSavedData.MemberKey member) {
+        WirelessAeSavedData data = WirelessAeSavedData.get(server);
+        UUID frequency = data.getMemberNetwork(member);
+        if (frequency != null && isMemberConnected(server, frequency, member)) {
+            return frequency;
+        }
+
+        return findWiredNetworkFrequency(server, member);
+    }
+
     public static UUID findWiredNetworkFrequency(MinecraftServer server, WirelessAeSavedData.MemberKey member) {
         IGridNode targetNode = findTargetNode(server, member);
         if (targetNode == null) {
@@ -821,7 +835,7 @@ public final class WirelessAeNetworkRuntime {
         }
 
         String className = target.getClass().getName();
-        return className.startsWith(GTCEU_ME_PART_PACKAGE) || className.startsWith(GTMTHINGS_ME_PART_PACKAGE) || className.startsWith(GTL_ME_PART_PACKAGE) || className.startsWith("appeng.") || className.startsWith("com.glodblock.github.extendedae.") || GTL_ME_TARGET_CLASSES.contains(className);
+        return className.startsWith(GTCEU_ME_PART_PACKAGE) || className.startsWith(GTMTHINGS_ME_PART_PACKAGE) || className.startsWith(GTL_ME_PART_PACKAGE) || GTL_ME_TARGET_CLASSES.contains(className);
     }
 
     private static boolean isWirelessMeTargetId(ResourceLocation blockId) {
@@ -831,7 +845,7 @@ public final class WirelessAeNetworkRuntime {
 
         String namespace = blockId.getNamespace();
         String path = blockId.getPath();
-        return "ae2".equals(namespace) || "appeng".equals(namespace) || "expatternprovider".equals(namespace) || "extendedae".equals(namespace) || "megacells".equals(namespace) || WIRELESS_ME_TARGET_IDS.contains(path) || ("merequester".equals(namespace) && isMeLikePath(path)) || ("gtmthings".equals(namespace) && isMeLikePath(path)) || (namespace.contains("ae") && isMeLikePath(path));
+        return WIRELESS_ME_TARGET_IDS.contains(path) || ("gtmthings".equals(namespace) && isMeLikePath(path));
     }
 
     private static boolean isMeLikePath(String path) {

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAeNetworkRuntime.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAeNetworkRuntime.java
@@ -26,6 +26,7 @@ import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
 
 import java.lang.reflect.Method;
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -327,13 +328,18 @@ public final class WirelessAeNetworkRuntime {
     }
 
     public static UUID findConnectedNetworkFrequency(MinecraftServer server, WirelessAeSavedData.MemberKey member) {
+        UUID wiredFrequency = findWiredNetworkFrequency(server, member);
+        if (wiredFrequency != null) {
+            return wiredFrequency;
+        }
+
         WirelessAeSavedData data = WirelessAeSavedData.get(server);
         UUID frequency = data.getMemberNetwork(member);
         if (frequency != null && isMemberConnected(server, frequency, member)) {
             return frequency;
         }
 
-        return findWiredNetworkFrequency(server, member);
+        return null;
     }
 
     public static UUID findWiredNetworkFrequency(MinecraftServer server, WirelessAeSavedData.MemberKey member) {
@@ -350,7 +356,7 @@ public final class WirelessAeNetworkRuntime {
             }
 
             IGridNode bridgeNode = findBridgeNode(core);
-            if (bridgeNode != null && isSameGrid(bridgeNode, targetNode)) {
+            if (areConnectedInWorld(bridgeNode, targetNode)) {
                 return network.frequency();
             }
         }
@@ -450,12 +456,18 @@ public final class WirelessAeNetworkRuntime {
             return ConnectionResult.TARGET_MISSING;
         }
 
+        IGridConnection currentConnection = frequencyConnections.get(member);
+        if (findWiredNetworkFrequency(bridgeNode.getLevel().getServer(), member) != null) {
+            destroyQuietly(currentConnection);
+            frequencyConnections.remove(member);
+            return ConnectionResult.ALREADY_CONNECTED;
+        }
+
         if (targetNode == bridgeNode) {
             destroyQuietly(frequencyConnections.remove(member));
             return ConnectionResult.ALREADY_CONNECTED;
         }
 
-        IGridConnection currentConnection = frequencyConnections.get(member);
         if (connectionMatches(currentConnection, bridgeNode, targetNode)) {
             return ConnectionResult.ALREADY_CONNECTED;
         }
@@ -874,6 +886,62 @@ public final class WirelessAeNetworkRuntime {
             return false;
         }
         return false;
+    }
+
+    private static boolean areConnectedInWorld(IGridNode coreNode, IGridNode targetNode) {
+        if (coreNode == null || targetNode == null) {
+            return false;
+        }
+        if (coreNode == targetNode) {
+            return true;
+        }
+
+        Set<IGridNode> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        ArrayDeque<IGridNode> pending = new ArrayDeque<>();
+        visited.add(coreNode);
+        pending.add(coreNode);
+
+        while (!pending.isEmpty()) {
+            IGridNode node = pending.removeFirst();
+            Iterable<IGridConnection> connections;
+            try {
+                connections = node.getConnections();
+            } catch (RuntimeException ignored) {
+                continue;
+            }
+
+            for (IGridConnection connection : connections) {
+                if (!isInWorldConnection(connection)) {
+                    continue;
+                }
+
+                IGridNode otherNode;
+                try {
+                    otherNode = connection.getOtherSide(node);
+                } catch (RuntimeException ignored) {
+                    continue;
+                }
+
+                if (otherNode == targetNode) {
+                    return true;
+                }
+                if (otherNode != null && visited.add(otherNode)) {
+                    pending.add(otherNode);
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isInWorldConnection(IGridConnection connection) {
+        if (connection == null) {
+            return false;
+        }
+        try {
+            return connection.isInWorld();
+        } catch (RuntimeException ignored) {
+            return false;
+        }
     }
 
     private static boolean isSameGrid(IGridNode coreNode, IGridNode targetNode) {

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAePackets.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAePackets.java
@@ -165,14 +165,24 @@ public final class WirelessAePackets {
                 BlockPos targetPos = target.blockPos();
                 GlobalPos targetGlobalPos = target.pos();
                 WirelessAeSavedData data = WirelessAeSavedData.get(level.getServer());
-                for (UUID currentNetwork : data.removeMembersAt(targetGlobalPos)) {
-                    WirelessAeNetworkRuntime.disconnectMembersAt(currentNetwork, targetGlobalPos);
-                }
+                UUID currentNetwork = data.getMemberNetwork(target);
+                UUID connectedNetwork = WirelessAeNetworkRuntime.findConnectedNetworkFrequency(level.getServer(), target);
+                boolean canModifyCurrentConnection = connectedNetwork != null && connectedNetwork.equals(currentNetwork) && WirelessAeNetworkRuntime.hasWirelessConnection(connectedNetwork, target);
 
                 if (packet.disconnect) {
+                    if (!canModifyCurrentConnection || !packet.frequency.equals(currentNetwork)) {
+                        return;
+                    }
+                    for (UUID removedNetwork : data.removeMembersAt(targetGlobalPos)) {
+                        WirelessAeNetworkRuntime.disconnectMembersAt(removedNetwork, targetGlobalPos);
+                    }
                     player.displayClientMessage(
                             Component.translatable("message.gtlcore.wireless_target.disconnected"),
                             true);
+                    return;
+                }
+
+                if (connectedNetwork != null && !canModifyCurrentConnection) {
                     return;
                 }
 
@@ -197,6 +207,10 @@ public final class WirelessAePackets {
                             Component.translatable("message.gtlcore.wireless_target.core_not_connected"),
                             true);
                     return;
+                }
+
+                for (UUID removedNetwork : data.removeMembersAt(targetGlobalPos)) {
+                    WirelessAeNetworkRuntime.disconnectMembersAt(removedNetwork, targetGlobalPos);
                 }
 
                 WirelessAeNetworkRuntime.ConnectionResult result = WirelessAeNetworkRuntime.connectMemberNow(
@@ -349,6 +363,7 @@ public final class WirelessAePackets {
                 buffer.writeUUID(entry.frequency());
                 buffer.writeUtf(entry.name());
                 buffer.writeBoolean(entry.connected());
+                buffer.writeBoolean(entry.disconnectable());
             }
         }
 
@@ -360,6 +375,7 @@ public final class WirelessAePackets {
                 entries.add(new TargetNetworkEntry(
                         buffer.readUUID(),
                         buffer.readUtf(32),
+                        buffer.readBoolean(),
                         buffer.readBoolean()));
             }
             return new SyncTargetNetworksPacket(targetPos, entries);
@@ -380,17 +396,21 @@ public final class WirelessAePackets {
         }
     }
 
-    public record TargetNetworkEntry(UUID frequency, String name, boolean connected) {}
+    public record TargetNetworkEntry(UUID frequency, String name, boolean connected, boolean disconnectable) {}
 
     private static List<TargetNetworkEntry> buildTargetEntries(ServerLevel level, WirelessAeSavedData.MemberKey target) {
         WirelessAeSavedData data = WirelessAeSavedData.get(level.getServer());
         UUID currentNetwork = data.getMemberNetwork(target);
+        UUID connectedNetwork = WirelessAeNetworkRuntime.findConnectedNetworkFrequency(level.getServer(), target);
         List<TargetNetworkEntry> entries = new ArrayList<>();
         for (WirelessAeSavedData.NetworkInfo network : data.getNetworkInfo()) {
+            boolean connected = network.frequency().equals(connectedNetwork);
+            boolean disconnectable = connected && network.frequency().equals(currentNetwork) && WirelessAeNetworkRuntime.hasWirelessConnection(network.frequency(), target);
             entries.add(new TargetNetworkEntry(
                     network.frequency(),
                     network.name(),
-                    network.frequency().equals(currentNetwork)));
+                    connected,
+                    disconnectable));
         }
         return entries;
     }

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAePackets.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAePackets.java
@@ -166,8 +166,9 @@ public final class WirelessAePackets {
                 GlobalPos targetGlobalPos = target.pos();
                 WirelessAeSavedData data = WirelessAeSavedData.get(level.getServer());
                 UUID currentNetwork = data.getMemberNetwork(target);
-                UUID connectedNetwork = WirelessAeNetworkRuntime.findConnectedNetworkFrequency(level.getServer(), target);
-                boolean canModifyCurrentConnection = connectedNetwork != null && connectedNetwork.equals(currentNetwork) && WirelessAeNetworkRuntime.hasWirelessConnection(connectedNetwork, target);
+                UUID wiredNetwork = WirelessAeNetworkRuntime.findWiredNetworkFrequency(level.getServer(), target);
+                UUID connectedNetwork = wiredNetwork == null ? WirelessAeNetworkRuntime.findConnectedNetworkFrequency(level.getServer(), target) : wiredNetwork;
+                boolean canModifyCurrentConnection = wiredNetwork == null && connectedNetwork != null && connectedNetwork.equals(currentNetwork) && WirelessAeNetworkRuntime.hasWirelessConnection(connectedNetwork, target);
 
                 if (packet.disconnect) {
                     if (!canModifyCurrentConnection || !packet.frequency.equals(currentNetwork)) {
@@ -401,11 +402,12 @@ public final class WirelessAePackets {
     private static List<TargetNetworkEntry> buildTargetEntries(ServerLevel level, WirelessAeSavedData.MemberKey target) {
         WirelessAeSavedData data = WirelessAeSavedData.get(level.getServer());
         UUID currentNetwork = data.getMemberNetwork(target);
-        UUID connectedNetwork = WirelessAeNetworkRuntime.findConnectedNetworkFrequency(level.getServer(), target);
+        UUID wiredNetwork = WirelessAeNetworkRuntime.findWiredNetworkFrequency(level.getServer(), target);
+        UUID connectedNetwork = wiredNetwork == null ? WirelessAeNetworkRuntime.findConnectedNetworkFrequency(level.getServer(), target) : wiredNetwork;
         List<TargetNetworkEntry> entries = new ArrayList<>();
         for (WirelessAeSavedData.NetworkInfo network : data.getNetworkInfo()) {
             boolean connected = network.frequency().equals(connectedNetwork);
-            boolean disconnectable = connected && network.frequency().equals(currentNetwork) && WirelessAeNetworkRuntime.hasWirelessConnection(network.frequency(), target);
+            boolean disconnectable = wiredNetwork == null && connected && network.frequency().equals(currentNetwork) && WirelessAeNetworkRuntime.hasWirelessConnection(network.frequency(), target);
             entries.add(new TargetNetworkEntry(
                     network.frequency(),
                     network.name(),

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAeTargetMenu.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAeTargetMenu.java
@@ -40,6 +40,7 @@ public class WirelessAeTargetMenu extends AbstractContainerMenu {
             this.networks.add(new Entry(
                     data.readUUID(),
                     data.readUtf(32),
+                    data.readBoolean(),
                     data.readBoolean()));
         }
     }
@@ -67,12 +68,16 @@ public class WirelessAeTargetMenu extends AbstractContainerMenu {
         BlockPos resolvedTargetPos = target.blockPos();
         WirelessAeSavedData data = WirelessAeSavedData.get(level.getServer());
         UUID currentNetwork = data.getMemberNetwork(target);
+        UUID connectedNetwork = WirelessAeNetworkRuntime.findConnectedNetworkFrequency(level.getServer(), target);
         List<Entry> entries = new ArrayList<>();
         for (WirelessAeSavedData.NetworkInfo network : data.getNetworkInfo()) {
+            boolean connected = network.frequency().equals(connectedNetwork);
+            boolean disconnectable = connected && network.frequency().equals(currentNetwork) && WirelessAeNetworkRuntime.hasWirelessConnection(network.frequency(), target);
             entries.add(new Entry(
                     network.frequency(),
                     network.name(),
-                    network.frequency().equals(currentNetwork)));
+                    connected,
+                    disconnectable));
         }
 
         NetworkHooks.openScreen(
@@ -108,6 +113,7 @@ public class WirelessAeTargetMenu extends AbstractContainerMenu {
             buffer.writeUUID(entry.frequency());
             buffer.writeUtf(entry.name());
             buffer.writeBoolean(entry.connected());
+            buffer.writeBoolean(entry.disconnectable());
         }
     }
 
@@ -124,7 +130,7 @@ public class WirelessAeTargetMenu extends AbstractContainerMenu {
                 this.targetPos.getZ() + 0.5D) <= 64.0D;
     }
 
-    public record Entry(UUID frequency, String name, boolean connected) {}
+    public record Entry(UUID frequency, String name, boolean connected, boolean disconnectable) {}
 
     private static void writeDirection(FriendlyByteBuf buffer, Direction direction) {
         buffer.writeBoolean(direction != null);

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAeTargetMenu.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessAeTargetMenu.java
@@ -68,11 +68,12 @@ public class WirelessAeTargetMenu extends AbstractContainerMenu {
         BlockPos resolvedTargetPos = target.blockPos();
         WirelessAeSavedData data = WirelessAeSavedData.get(level.getServer());
         UUID currentNetwork = data.getMemberNetwork(target);
-        UUID connectedNetwork = WirelessAeNetworkRuntime.findConnectedNetworkFrequency(level.getServer(), target);
+        UUID wiredNetwork = WirelessAeNetworkRuntime.findWiredNetworkFrequency(level.getServer(), target);
+        UUID connectedNetwork = wiredNetwork == null ? WirelessAeNetworkRuntime.findConnectedNetworkFrequency(level.getServer(), target) : wiredNetwork;
         List<Entry> entries = new ArrayList<>();
         for (WirelessAeSavedData.NetworkInfo network : data.getNetworkInfo()) {
             boolean connected = network.frequency().equals(connectedNetwork);
-            boolean disconnectable = connected && network.frequency().equals(currentNetwork) && WirelessAeNetworkRuntime.hasWirelessConnection(network.frequency(), target);
+            boolean disconnectable = wiredNetwork == null && connected && network.frequency().equals(currentNetwork) && WirelessAeNetworkRuntime.hasWirelessConnection(network.frequency(), target);
             entries.add(new Entry(
                     network.frequency(),
                     network.name(),

--- a/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/WirelessAeNetworkProvider.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/WirelessAeNetworkProvider.java
@@ -29,8 +29,6 @@ public class WirelessAeNetworkProvider implements IBlockComponentProvider, IServ
     private static final ResourceLocation UID = GTLCore.id("wireless_ae_network_provider");
     private static final String TAG_PRESENT = "gtlcore_wireless_ae";
     private static final String TAG_CORE = "wireless_ae_core";
-    private static final String TAG_BOUND = "wireless_ae_bound";
-    private static final String TAG_CONNECTED = "wireless_ae_connected";
     private static final String TAG_NETWORK_NAME = "wireless_ae_network_name";
 
     @Override
@@ -40,27 +38,18 @@ public class WirelessAeNetworkProvider implements IBlockComponentProvider, IServ
             return;
         }
 
-        boolean connected = serverData.getBoolean(TAG_CONNECTED);
         if (serverData.getBoolean(TAG_CORE)) {
-            tooltip.add(Component.translatable(connected ?
-                    "tooltip.gtlcore.wireless_ae.core_connected" :
-                    "tooltip.gtlcore.wireless_ae.core_disconnected",
+            tooltip.add(Component.translatable(
+                    "tooltip.gtlcore.wireless_ae.core_connected",
                     serverData.getString(TAG_NETWORK_NAME))
-                    .withStyle(connected ? ChatFormatting.GREEN : ChatFormatting.YELLOW));
+                    .withStyle(ChatFormatting.GREEN));
             return;
         }
 
-        if (!serverData.getBoolean(TAG_BOUND)) {
-            tooltip.add(Component.translatable("tooltip.gtlcore.wireless_ae.target_unbound")
-                    .withStyle(ChatFormatting.GRAY));
-            return;
-        }
-
-        tooltip.add(Component.translatable(connected ?
-                "tooltip.gtlcore.wireless_ae.target_connected" :
-                "tooltip.gtlcore.wireless_ae.target_waiting",
+        tooltip.add(Component.translatable(
+                "tooltip.gtlcore.wireless_ae.target_connected",
                 serverData.getString(TAG_NETWORK_NAME))
-                .withStyle(connected ? ChatFormatting.GREEN : ChatFormatting.YELLOW));
+                .withStyle(ChatFormatting.GREEN));
     }
 
     @Override
@@ -89,35 +78,25 @@ public class WirelessAeNetworkProvider implements IBlockComponentProvider, IServ
                 blockAccessor.getSide(),
                 hitLocation);
         WirelessAeSavedData savedData = WirelessAeSavedData.get(serverLevel.getServer());
-        UUID frequency = savedData.getMemberNetwork(target);
-        boolean connected = false;
-
-        if (frequency != null) {
-            connected = WirelessAeNetworkRuntime.isMemberConnected(serverLevel.getServer(), frequency, target);
-        } else {
-            frequency = WirelessAeNetworkRuntime.findWiredNetworkFrequency(serverLevel.getServer(), target);
-            connected = frequency != null;
+        UUID frequency = WirelessAeNetworkRuntime.findConnectedNetworkFrequency(serverLevel.getServer(), target);
+        if (frequency == null) {
+            return;
         }
 
         data.putBoolean(TAG_PRESENT, true);
         data.putBoolean(TAG_CORE, false);
-        data.putBoolean(TAG_BOUND, frequency != null);
-        if (frequency == null) {
-            data.putBoolean(TAG_CONNECTED, false);
-            return;
-        }
-
-        data.putBoolean(TAG_CONNECTED, connected);
         data.putString(TAG_NETWORK_NAME, savedData.getNetworkName(frequency));
     }
 
     private static void appendCoreData(CompoundTag data, ServerLevel level, WirelessNetworkCoreBlockEntity core) {
+        if (!core.isLinkedToAeNetwork()) {
+            return;
+        }
+
         WirelessAeSavedData savedData = WirelessAeSavedData.get(level.getServer());
         UUID frequency = core.getFrequency();
         data.putBoolean(TAG_PRESENT, true);
         data.putBoolean(TAG_CORE, true);
-        data.putBoolean(TAG_BOUND, true);
-        data.putBoolean(TAG_CONNECTED, core.isLinkedToAeNetwork());
         data.putString(TAG_NETWORK_NAME, savedData.getNetworkName(frequency));
     }
 

--- a/src/main/resources/assets/gtlcore/lang/en_us.json
+++ b/src/main/resources/assets/gtlcore/lang/en_us.json
@@ -434,8 +434,5 @@
   "message.gtlcore.wireless_target.linked_target": "Linked ME hatch to the wireless ME network (%s).",
   "message.gtlcore.wireless_target.linked_target_pending": "Recorded this ME block and waiting for the wireless ME network connection (%s).",
   "tooltip.gtlcore.wireless_ae.core_connected": "Wireless ME network: %s (attached to an ME network)",
-  "tooltip.gtlcore.wireless_ae.core_disconnected": "Wireless ME network: %s (not attached to an ME network)",
-  "tooltip.gtlcore.wireless_ae.target_unbound": "Wireless ME network: not connected",
-  "tooltip.gtlcore.wireless_ae.target_connected": "Wireless ME network: %s (connected)",
-  "tooltip.gtlcore.wireless_ae.target_waiting": "Wireless ME network: %s (waiting for connection)"
+  "tooltip.gtlcore.wireless_ae.target_connected": "Wireless ME network: %s (connected)"
 }

--- a/src/main/resources/assets/gtlcore/lang/zh_cn.json
+++ b/src/main/resources/assets/gtlcore/lang/zh_cn.json
@@ -434,8 +434,5 @@
   "message.gtlcore.wireless_target.linked_target": "已将 ME 仓室接入无线 ME 网络（%s）。",
   "message.gtlcore.wireless_target.linked_target_pending": "已记录这个 ME 方块，等待无线 ME 网络连接（%s）。",
   "tooltip.gtlcore.wireless_ae.core_connected": "无线 ME 网络：%s（已接入 ME 网络）",
-  "tooltip.gtlcore.wireless_ae.core_disconnected": "无线 ME 网络：%s（未接入 ME 网络）",
-  "tooltip.gtlcore.wireless_ae.target_unbound": "无线 ME 网络：未连接",
-  "tooltip.gtlcore.wireless_ae.target_connected": "无线 ME 网络：%s（已连接）",
-  "tooltip.gtlcore.wireless_ae.target_waiting": "无线 ME 网络：%s（等待连接）"
+  "tooltip.gtlcore.wireless_ae.target_connected": "无线 ME 网络：%s（已连接）"
 }


### PR DESCRIPTION
修改内容：
- 仅保留多方块结构 ME 仓室的无线 ME 网络入口与 Jade 信息。
- Jade 只在已连接到无线 ME 网络时显示连接信息。
- 线缆接入含无线 ME 网络核心的 ME 网络时，UI 显示已连接但禁止修改连接网络。