### PR TITLE
修复样板包装箱与终端相关问题

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/api/pattern/AdvancedBlockPattern.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/pattern/AdvancedBlockPattern.java
@@ -258,36 +258,36 @@ public class AdvancedBlockPattern extends BlockPattern {
 
                         ItemStack found = null;
                         net.minecraft.world.level.material.Fluid fluidToPlace = null;
+                        boolean foundFromAE = false;
+                        boolean fluidFromAE = false;
                         IItemHandler handler = null;
                         int foundSlot = -1;
                         for (ItemStack candidate : candidates) {
                             net.minecraft.world.level.material.Fluid fluid = getFluid(candidate);
                             if (fluid != null) {
-                                if (aeMode) {
-                                    if (aeInventory != null && aeInventory.extract(AEFluidKey.of(fluid), FluidType.BUCKET_VOLUME, Actionable.SIMULATE, source) >= FluidType.BUCKET_VOLUME) {
-                                        fluidToPlace = fluid;
-                                        break;
-                                    }
-                                } else {
-                                    if (extractFluidFromPlayerRecursively(player, fluid)) {
-                                        fluidToPlace = fluid;
-                                        break;
-                                    }
+                                if (aeMode && aeInventory != null &&
+                                        aeInventory.extract(AEFluidKey.of(fluid), FluidType.BUCKET_VOLUME, Actionable.SIMULATE, source) >= FluidType.BUCKET_VOLUME) {
+                                    fluidToPlace = fluid;
+                                    fluidFromAE = true;
+                                    break;
+                                }
+                                if (extractFluidFromPlayerRecursively(player, fluid)) {
+                                    fluidToPlace = fluid;
+                                    break;
                                 }
                             } else {
-                                if (aeMode) {
-                                    if (aeInventory != null && aeInventory.extract(AEItemKey.of(candidate), 1, Actionable.SIMULATE, source) > 0) {
-                                        found = candidate.copy();
-                                        break;
-                                    }
-                                } else {
-                                    var result = foundItem(player, List.of(candidate), item -> true);
-                                    if (result.getA() != null) {
-                                        found = result.getA();
-                                        handler = result.getB();
-                                        foundSlot = result.getC();
-                                        break;
-                                    }
+                                if (aeMode && aeInventory != null &&
+                                        aeInventory.extract(AEItemKey.of(candidate), 1, Actionable.SIMULATE, source) > 0) {
+                                    found = candidate.copy();
+                                    foundFromAE = true;
+                                    break;
+                                }
+                                var result = foundItem(player, List.of(candidate), item -> true);
+                                if (result.getA() != null) {
+                                    found = result.getA();
+                                    handler = result.getB();
+                                    foundSlot = result.getC();
+                                    break;
                                 }
                             }
                         }
@@ -298,11 +298,7 @@ public class AdvancedBlockPattern extends BlockPattern {
                         IItemHandler holderHandler = null;
                         int holderSlot = -1;
                         if (autoBuildSetting.isReplaceMode() && itemStack != null) {
-                            if (aeMode) {
-                                if (!canInsertItemIntoAE(aeInventory, itemStack, source)) {
-                                    continue;
-                                }
-                            } else {
+                            if (!aeMode || !canInsertItemIntoAE(aeInventory, itemStack, source)) {
                                 var holderResult = foundHolderSlot(player, itemStack);
                                 holderHandler = holderResult.first();
                                 holderSlot = holderResult.rightInt();
@@ -315,9 +311,9 @@ public class AdvancedBlockPattern extends BlockPattern {
 
                         if (autoBuildSetting.isReplaceMode() && itemStack != null) {
                             world.removeBlock(pos, true);
-                            if (aeMode) {
-                                aeInventory.insert(AEItemKey.of(itemStack), itemStack.getCount(), Actionable.MODULATE, source);
-                            } else if (holderHandler != null) holderHandler.insertItem(holderSlot, itemStack, false);
+                            if (!insertItemIntoAE(aeInventory, itemStack, source) && holderHandler != null) {
+                                holderHandler.insertItem(holderSlot, itemStack, false);
+                            }
                         }
 
                         if (fluidToPlace != null) {
@@ -326,7 +322,7 @@ public class AdvancedBlockPattern extends BlockPattern {
                                 world.setBlock(pos, state, 3);
                                 placeBlockPos.add(pos);
                                 blocks.put(pos, state);
-                                if (aeMode) {
+                                if (fluidFromAE) {
                                     aeInventory.extract(AEFluidKey.of(fluidToPlace), FluidType.BUCKET_VOLUME, Actionable.MODULATE, source);
                                 }
                             }
@@ -336,7 +332,7 @@ public class AdvancedBlockPattern extends BlockPattern {
                             InteractionResult interactionResult = itemBlock.place(context);
                             if (interactionResult != InteractionResult.FAIL) {
                                 placeBlockPos.add(pos);
-                                if (aeMode) {
+                                if (foundFromAE) {
                                     aeInventory.extract(AEItemKey.of(found), 1, Actionable.MODULATE, source);
                                 } else if (handler != null) handler.extractItem(foundSlot, 1, false);
                             }
@@ -427,7 +423,7 @@ public class AdvancedBlockPattern extends BlockPattern {
                             if (level instanceof ServerLevel serverLevel) {
                                 if (blockState.getBlock() instanceof LiquidBlock liquidBlock) {
                                     if (aeInventory != null) {
-                                        aeInventory.insert(AEFluidKey.of(liquidBlock.getFluid()), 1000, Actionable.MODULATE, source);
+                                        aeInventory.insert(AEFluidKey.of(liquidBlock.getFluid()), FluidType.BUCKET_VOLUME, Actionable.MODULATE, source);
                                     }
                                     level.setBlock(pos, Blocks.AIR.defaultBlockState(), 3);
                                     continue;
@@ -442,9 +438,7 @@ public class AdvancedBlockPattern extends BlockPattern {
                                     ItemStack remainder = drop;
                                     if (aeInventory != null) {
                                         long inserted = aeInventory.insert(AEItemKey.of(remainder), remainder.getCount(), Actionable.MODULATE, source);
-                                        if (inserted == remainder.getCount()) {
-                                            remainder = ItemStack.EMPTY;
-                                        } else {
+                                        if (inserted > 0) {
                                             remainder.shrink((int) inserted);
                                         }
                                     }
@@ -556,6 +550,13 @@ public class AdvancedBlockPattern extends BlockPattern {
 
     private boolean canInsertItemIntoAE(@Nullable MEStorage aeInventory, ItemStack stack, IActionSource source) {
         return aeInventory != null && aeInventory.insert(AEItemKey.of(stack), stack.getCount(), Actionable.SIMULATE, source) >= stack.getCount();
+    }
+
+    private boolean insertItemIntoAE(@Nullable MEStorage aeInventory, ItemStack stack, IActionSource source) {
+        if (!canInsertItemIntoAE(aeInventory, stack, source)) {
+            return false;
+        }
+        return aeInventory.insert(AEItemKey.of(stack), stack.getCount(), Actionable.MODULATE, source) >= stack.getCount();
     }
 
     public static IGridNode getGridNode(BlockEntity be) {

--- a/src/main/java/org/gtlcore/gtlcore/api/pattern/AdvancedBlockPattern.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/pattern/AdvancedBlockPattern.java
@@ -35,6 +35,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.items.IItemHandler;
@@ -48,6 +49,7 @@ import appeng.api.networking.IGridNode;
 import appeng.api.networking.security.IActionSource;
 import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEItemKey;
+import appeng.api.storage.MEStorage;
 import it.unimi.dsi.fastutil.ints.IntObjectPair;
 import it.unimi.dsi.fastutil.objects.*;
 import org.apache.commons.lang3.ArrayUtils;
@@ -256,38 +258,29 @@ public class AdvancedBlockPattern extends BlockPattern {
 
                         ItemStack found = null;
                         net.minecraft.world.level.material.Fluid fluidToPlace = null;
-                        boolean fromAE = false;
                         IItemHandler handler = null;
                         int foundSlot = -1;
                         for (ItemStack candidate : candidates) {
                             net.minecraft.world.level.material.Fluid fluid = getFluid(candidate);
                             if (fluid != null) {
-                                // 1. Try AE Fluid
-                                if (aeInventory != null) {
-                                    if (aeInventory.extract(AEFluidKey.of(fluid), 1000, Actionable.MODULATE, source) >= 1000) {
+                                if (aeMode) {
+                                    if (aeInventory != null && aeInventory.extract(AEFluidKey.of(fluid), FluidType.BUCKET_VOLUME, Actionable.SIMULATE, source) >= FluidType.BUCKET_VOLUME) {
                                         fluidToPlace = fluid;
-                                        fromAE = true;
                                         break;
                                     }
-                                }
-                                // 2. Try Player Inv Fluid (Recursive)
-                                if (fluidToPlace == null) {
+                                } else {
                                     if (extractFluidFromPlayerRecursively(player, fluid)) {
                                         fluidToPlace = fluid;
                                         break;
                                     }
                                 }
                             } else {
-                                // 1. Try AE Item
-                                if (aeInventory != null) {
-                                    if (aeInventory.extract(AEItemKey.of(candidate), 1, Actionable.MODULATE, source) > 0) {
+                                if (aeMode) {
+                                    if (aeInventory != null && aeInventory.extract(AEItemKey.of(candidate), 1, Actionable.SIMULATE, source) > 0) {
                                         found = candidate.copy();
-                                        fromAE = true;
                                         break;
                                     }
-                                }
-                                // 2. Try Player Inv Item
-                                if (found == null) {
+                                } else {
                                     var result = foundItem(player, List.of(candidate), item -> true);
                                     if (result.getA() != null) {
                                         found = result.getA();
@@ -305,18 +298,26 @@ public class AdvancedBlockPattern extends BlockPattern {
                         IItemHandler holderHandler = null;
                         int holderSlot = -1;
                         if (autoBuildSetting.isReplaceMode() && itemStack != null) {
-                            var holderResult = foundHolderSlot(player, itemStack);
-                            holderHandler = holderResult.first();
-                            holderSlot = holderResult.rightInt();
+                            if (aeMode) {
+                                if (!canInsertItemIntoAE(aeInventory, itemStack, source)) {
+                                    continue;
+                                }
+                            } else {
+                                var holderResult = foundHolderSlot(player, itemStack);
+                                holderHandler = holderResult.first();
+                                holderSlot = holderResult.rightInt();
 
-                            if (holderHandler != null && holderSlot < 0) {
-                                continue;
+                                if (holderHandler != null && holderSlot < 0) {
+                                    continue;
+                                }
                             }
                         }
 
                         if (autoBuildSetting.isReplaceMode() && itemStack != null) {
                             world.removeBlock(pos, true);
-                            if (holderHandler != null) holderHandler.insertItem(holderSlot, itemStack, false);
+                            if (aeMode) {
+                                aeInventory.insert(AEItemKey.of(itemStack), itemStack.getCount(), Actionable.MODULATE, source);
+                            } else if (holderHandler != null) holderHandler.insertItem(holderSlot, itemStack, false);
                         }
 
                         if (fluidToPlace != null) {
@@ -325,6 +326,9 @@ public class AdvancedBlockPattern extends BlockPattern {
                                 world.setBlock(pos, state, 3);
                                 placeBlockPos.add(pos);
                                 blocks.put(pos, state);
+                                if (aeMode) {
+                                    aeInventory.extract(AEFluidKey.of(fluidToPlace), FluidType.BUCKET_VOLUME, Actionable.MODULATE, source);
+                                }
                             }
                         } else if (found != null && found.getItem() instanceof BlockItem itemBlock) {
                             BlockPlaceContext context = new BlockPlaceContext(world, player, InteractionHand.MAIN_HAND,
@@ -332,7 +336,9 @@ public class AdvancedBlockPattern extends BlockPattern {
                             InteractionResult interactionResult = itemBlock.place(context);
                             if (interactionResult != InteractionResult.FAIL) {
                                 placeBlockPos.add(pos);
-                                if (handler != null && !fromAE) handler.extractItem(foundSlot, 1, false);
+                                if (aeMode) {
+                                    aeInventory.extract(AEItemKey.of(found), 1, Actionable.MODULATE, source);
+                                } else if (handler != null) handler.extractItem(foundSlot, 1, false);
                             }
                             if (world.getBlockEntity(pos) instanceof IMachineBlockEntity machineBlockEntity) {
                                 blocks.put(pos, machineBlockEntity.getMetaMachine());
@@ -546,6 +552,10 @@ public class AdvancedBlockPattern extends BlockPattern {
             }
         }
         return null;
+    }
+
+    private boolean canInsertItemIntoAE(@Nullable MEStorage aeInventory, ItemStack stack, IActionSource source) {
+        return aeInventory != null && aeInventory.insert(AEItemKey.of(stack), stack.getCount(), Actionable.SIMULATE, source) >= stack.getCount();
     }
 
     public static IGridNode getGridNode(BlockEntity be) {

--- a/src/main/java/org/gtlcore/gtlcore/common/item/PatternBoxBehavior.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/item/PatternBoxBehavior.java
@@ -1,13 +1,17 @@
 package org.gtlcore.gtlcore.common.item;
 
-import org.gtlcore.gtlcore.common.machine.multiblock.part.ae.MEPatternBufferPartMachine;
-
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.item.component.IItemUIFactory;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
 
 import com.lowdragmc.lowdraglib.gui.factory.HeldItemUIFactory;
 import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
+import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
+import com.lowdragmc.lowdraglib.gui.texture.TextTexture;
+import com.lowdragmc.lowdraglib.gui.widget.ButtonWidget;
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.SlotWidget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
@@ -26,6 +30,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec3;
 
@@ -33,15 +38,23 @@ import appeng.api.crafting.PatternDetailsHelper;
 import appeng.api.inventories.InternalInventory;
 import appeng.api.parts.IPart;
 import appeng.blockentity.networking.CableBusBlockEntity;
+import appeng.blockentity.crafting.IMolecularAssemblerSupportedPattern;
+import appeng.crafting.pattern.EncodedPatternItem;
+import appeng.helpers.patternprovider.PatternContainer;
 import appeng.helpers.patternprovider.PatternProviderLogicHost;
+import appeng.util.inv.CombinedInternalInventory;
+import appeng.util.inv.FilteredInternalInventory;
+import appeng.util.inv.filter.IAEItemFilter;
+import com.glodblock.github.extendedae.common.me.matrix.ClusterAssemblerMatrix;
+import com.glodblock.github.extendedae.common.tileentities.matrix.TileAssemblerMatrixBase;
+import com.glodblock.github.extendedae.common.tileentities.matrix.TileAssemblerMatrixPattern;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * 样板包装箱：仅可存储已编码样板，容量 72。
- * <p>
- * - 对空气右键（非潜行）：打开 UI。<br>
- * - 右键样板供应器（及实现 {@link PatternProviderLogicHost} 或 {@link MEPatternBufferPartMachine} 的方块）：取出其中的样板到包装箱。<br>
- * - 潜行右键对应方块：将包装箱内的样板放入供应器。
+ * Stores encoded patterns and moves them to or from AE pattern containers.
  */
 public class PatternBoxBehavior implements IItemUIFactory {
 
@@ -51,17 +64,25 @@ public class PatternBoxBehavior implements IItemUIFactory {
     private static final String INV_TAG = "PatternInv";
 
     private static final int COLS = 9;
-    private static final int ROWS = SLOT_COUNT / COLS;
+    private static final int VISIBLE_SLOT_COUNT = 36;
+    private static final int ROWS = VISIBLE_SLOT_COUNT / COLS;
+    private static final int MAX_PAGE = (SLOT_COUNT + VISIBLE_SLOT_COUNT - 1) / VISIBLE_SLOT_COUNT;
     private static final int SLOT_SIZE = 18;
     private static final int LEFT = 7;
-    private static final int PATTERN_TOP = 18;
-    // 样板区底部 + 间距后放置玩家背包
+    private static final int PATTERN_TOP = 42;
+    // Pattern grid bottom plus spacing before the player inventory.
     private static final int INV_TOP = PATTERN_TOP + ROWS * SLOT_SIZE + 8;
     private static final int WIDTH = 176;
     private static final int HEIGHT = INV_TOP + 82;
+    private static final int PAGE_BUTTON_Y = 24;
+    private static final int PREVIOUS_PAGE_BUTTON_X = 136;
+    private static final int PAGE_LABEL_X = 104;
+    private static final int PAGE_LABEL_Y = 29;
+    private static final int NEXT_PAGE_BUTTON_X = 154;
+    private static final int PAGE_BUTTON_SIZE = 16;
 
     /**
-     * 读取包装箱内部库存。库存仅接受已编码样板。
+     * Reads the box inventory. Only encoded patterns are accepted.
      */
     public static ItemStackTransfer getInventory(ItemStack pouch) {
         ItemStackTransfer transfer = new ItemStackTransfer(SLOT_COUNT);
@@ -73,7 +94,7 @@ public class PatternBoxBehavior implements IItemUIFactory {
     }
 
     /**
-     * 将库存写回包装箱 NBT。
+     * Writes the inventory back into the box NBT.
      */
     public static void saveInventory(ItemStack pouch, ItemStackTransfer transfer) {
         pouch.getOrCreateTag().put(INV_TAG, transfer.serializeNBT());
@@ -89,23 +110,19 @@ public class PatternBoxBehavior implements IItemUIFactory {
         });
 
         WidgetGroup group = new WidgetGroup(0, 0, WIDTH, HEIGHT);
-        group.addWidget(new LabelWidget(LEFT, 6, Component.translatable("item.gtlcore.pattern_box")));
+        group.addWidget(new LabelWidget(LEFT, 6, () -> Component.translatable("item.gtlcore.pattern_box").getString()));
 
-        // 36 个样板槽：4 行 x 9 列
-        for (int i = 0; i < SLOT_COUNT; i++) {
-            int row = i / COLS;
-            int col = i % COLS;
-            group.addWidget(new SlotWidget(inventory, i,
-                    LEFT + col * SLOT_SIZE, PATTERN_TOP + row * SLOT_SIZE, true, true)
-                    .setBackgroundTexture(GuiTextures.SLOT)
-                    .setIngredientIO(IngredientIO.INPUT));
-        }
+        // 36 pattern slots: 4 rows x 9 columns.
+        int[] page = { 0 };
+        WidgetGroup patternPage = new WidgetGroup(0, 0, WIDTH, PATTERN_TOP + ROWS * SLOT_SIZE);
+        rebuildPatternPage(patternPage, inventory, page);
+        group.addWidget(patternPage);
 
-        // 手动构建玩家背包，与样板槽相同的对齐方式
+        // Build the player inventory manually so it aligns with the pattern grid.
         Inventory playerInv = player.getInventory();
-        // 锁定当前持有包装箱的槽位，避免 UI 打开期间被移走导致引用失效
+        // Lock the slot that currently holds this box while its UI is open.
         int heldSlot = holder.getHand() == InteractionHand.MAIN_HAND ? playerInv.selected : -1;
-        // 主背包 3 行 x 9 列（槽位 9..35）
+        // Main inventory: 3 rows x 9 columns, slots 9..35.
         for (int row = 0; row < 3; row++) {
             for (int col = 0; col < COLS; col++) {
                 int index = col + (row + 1) * COLS;
@@ -114,7 +131,7 @@ public class PatternBoxBehavior implements IItemUIFactory {
                         .setBackgroundTexture(GuiTextures.SLOT));
             }
         }
-        // 快捷栏 1 行 x 9 列（槽位 0..8）
+        // Hotbar: 1 row x 9 columns, slots 0..8.
         int hotbarY = INV_TOP + 3 * SLOT_SIZE + 4;
         for (int col = 0; col < COLS; col++) {
             boolean locked = col == heldSlot;
@@ -131,7 +148,7 @@ public class PatternBoxBehavior implements IItemUIFactory {
     @Override
     public InteractionResultHolder<ItemStack> use(Item item, Level level, Player player, InteractionHand usedHand) {
         ItemStack stack = player.getItemInHand(usedHand);
-        // 潜行右键空气不打开 UI（潜行用于向供应器写入样板）
+        // Sneak-use is reserved for pushing patterns into a target container.
         if (player.isShiftKeyDown()) {
             return new InteractionResultHolder<>(InteractionResult.PASS, stack);
         }
@@ -142,9 +159,24 @@ public class PatternBoxBehavior implements IItemUIFactory {
     }
 
     @Override
+    public boolean sneakBypassUse(ItemStack stack, LevelReader level, BlockPos pos, Player player) {
+        return true;
+    }
+
+    @Override
     public InteractionResult onItemUseFirst(ItemStack itemStack, UseOnContext context) {
+        InteractionResult result = handleBlockUse(itemStack, context);
+        return result == InteractionResult.PASS ? InteractionResult.PASS : InteractionResult.sidedSuccess(context.getLevel().isClientSide);
+    }
+
+    @Override
+    public InteractionResult useOn(UseOnContext context) {
+        return handleBlockUse(context.getItemInHand(), context);
+    }
+
+    public static InteractionResult handleBlockUse(ItemStack itemStack, UseOnContext context) {
         if (!(context.getPlayer() instanceof ServerPlayer serverPlayer)) {
-            return InteractionResult.PASS;
+            return isPotentialPatternTarget(context) ? InteractionResult.SUCCESS : InteractionResult.PASS;
         }
 
         InternalInventory providerInv = resolveProviderInventory(context);
@@ -155,7 +187,7 @@ public class PatternBoxBehavior implements IItemUIFactory {
         ItemStackTransfer pouchInv = getInventory(itemStack);
         boolean changed;
         if (serverPlayer.isShiftKeyDown()) {
-            // 潜行右键：包装箱 -> 供应器
+            // Sneak right-click: box -> target container.
             changed = movePouchToProvider(pouchInv, providerInv);
             if (changed) {
                 saveInventory(itemStack, pouchInv);
@@ -164,7 +196,7 @@ public class PatternBoxBehavior implements IItemUIFactory {
                 serverPlayer.displayClientMessage(Component.translatable("message.gtlcore.pattern_box_insert_failed"), true);
             }
         } else {
-            // 右键：供应器 -> 包装箱
+            // Right-click: target container -> box.
             changed = moveProviderToPouch(providerInv, pouchInv);
             if (changed) {
                 saveInventory(itemStack, pouchInv);
@@ -177,18 +209,35 @@ public class PatternBoxBehavior implements IItemUIFactory {
     }
 
     /**
-     * 从点击的方块解析样板供应器库存，命中以下三类：
-     * <ul>
-     * <li>AE2 线缆总线上的样板供应器部件</li>
-     * <li>实现 {@link PatternProviderLogicHost} 的方块（样板供应器方块）</li>
-     * <li>GTLCore 的 {@link MEPatternBufferPartMachine}（样板总成）</li>
-     * </ul>
+     * Resolves AE pattern providers, pattern buffers, and multiblock pattern containers.
      */
     @Nullable
     private static InternalInventory resolveProviderInventory(UseOnContext context) {
         Level level = context.getLevel();
         BlockPos pos = context.getClickedPos();
         BlockEntity tile = level.getBlockEntity(pos);
+
+        InternalInventory assemblerMatrixInventory = resolveAssemblerMatrixInventory(tile, level);
+        if (assemblerMatrixInventory != null) {
+            return assemblerMatrixInventory;
+        }
+
+        MetaMachine metaMachine = MetaMachine.getMachine(level, pos);
+        if (metaMachine instanceof PatternContainer patternContainer) {
+            return patternContainer.getTerminalPatternInventory();
+        }
+        if (metaMachine instanceof IMultiController controller) {
+            InternalInventory inventory = resolvePatternContainerInventory(controller);
+            if (inventory != null) {
+                return inventory;
+            }
+        }
+        if (metaMachine instanceof IMultiPart part) {
+            InternalInventory inventory = resolvePatternContainerInventory(part);
+            if (inventory != null) {
+                return inventory;
+            }
+        }
 
         if (tile instanceof CableBusBlockEntity cable) {
             Vec3 hitVec = context.getClickLocation();
@@ -202,15 +251,150 @@ public class PatternBoxBehavior implements IItemUIFactory {
         if (tile instanceof PatternProviderLogicHost providerBlock) {
             return providerBlock.getLogic().getPatternInv();
         }
-        if (tile instanceof MetaMachineBlockEntity mmbe &&
-                mmbe.getMetaMachine() instanceof MEPatternBufferPartMachine buffer) {
-            return buffer.getTerminalPatternInventory();
+        if (tile instanceof MetaMachineBlockEntity mmbe) {
+            Object machine = mmbe.getMetaMachine();
+            if (machine instanceof PatternContainer patternContainer) {
+                return patternContainer.getTerminalPatternInventory();
+            }
+            if (machine instanceof IMultiController controller) {
+                return resolvePatternContainerInventory(controller);
+            }
+            if (machine instanceof IMultiPart part) {
+                return resolvePatternContainerInventory(part);
+            }
         }
         return null;
     }
 
+    private static boolean isPotentialPatternTarget(UseOnContext context) {
+        Level level = context.getLevel();
+        BlockPos pos = context.getClickedPos();
+        BlockEntity tile = level.getBlockEntity(pos);
+        MetaMachine metaMachine = MetaMachine.getMachine(level, pos);
+        if (tile instanceof CableBusBlockEntity || tile instanceof PatternProviderLogicHost) {
+            return true;
+        }
+        if (isAssemblerMatrix(tile)) {
+            return true;
+        }
+        if (metaMachine instanceof PatternContainer ||
+                metaMachine instanceof IMultiController ||
+                metaMachine instanceof IMultiPart) {
+            return true;
+        }
+        if (tile instanceof MetaMachineBlockEntity mmbe) {
+            Object machine = mmbe.getMetaMachine();
+            return machine instanceof PatternContainer ||
+                    machine instanceof IMultiController ||
+                    machine instanceof IMultiPart;
+        }
+        return false;
+    }
+
+    @Nullable
+    private static InternalInventory resolveAssemblerMatrixInventory(@Nullable BlockEntity tile, Level level) {
+        if (tile instanceof TileAssemblerMatrixPattern patternTile) {
+            return createAssemblerMatrixPatternInventory(patternTile, level);
+        }
+        if (!(tile instanceof TileAssemblerMatrixBase matrixBase)) {
+            return null;
+        }
+        ClusterAssemblerMatrix cluster = matrixBase.getCluster();
+        if (cluster == null || cluster.isDestroyed()) {
+            return null;
+        }
+        List<InternalInventory> inventories = new ArrayList<>();
+        for (TileAssemblerMatrixPattern patternTile : cluster.getPatterns()) {
+            if (patternTile != null && patternTile.isValid()) {
+                inventories.add(createAssemblerMatrixPatternInventory(patternTile, level));
+            }
+        }
+        if (inventories.isEmpty()) {
+            return null;
+        }
+        return inventories.size() == 1 ? inventories.get(0) :
+                new CombinedInternalInventory(inventories.toArray(InternalInventory[]::new));
+    }
+
+    private static InternalInventory createAssemblerMatrixPatternInventory(TileAssemblerMatrixPattern patternTile, Level level) {
+        return new FilteredInternalInventory(patternTile.getTerminalPatternInventory(), new IAEItemFilter() {
+
+            @Override
+            public boolean allowInsert(InternalInventory inv, int slot, ItemStack stack) {
+                return stack.getItem() instanceof EncodedPatternItem &&
+                        PatternDetailsHelper.decodePattern(stack, level) instanceof IMolecularAssemblerSupportedPattern;
+            }
+        });
+    }
+
+    private static boolean isAssemblerMatrix(@Nullable BlockEntity tile) {
+        return tile instanceof TileAssemblerMatrixBase;
+    }
+
+    @Nullable
+    private static InternalInventory resolvePatternContainerInventory(IMultiController controller) {
+        if (!controller.isFormed()) {
+            return null;
+        }
+        return resolvePatternContainerInventory(controller.getParts());
+    }
+
+    @Nullable
+    private static InternalInventory resolvePatternContainerInventory(IMultiPart part) {
+        if (!part.isFormed()) {
+            return null;
+        }
+        for (IMultiController controller : part.getControllers()) {
+            InternalInventory inventory = resolvePatternContainerInventory(controller);
+            if (inventory != null) {
+                return inventory;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static InternalInventory resolvePatternContainerInventory(Iterable<IMultiPart> parts) {
+        for (IMultiPart part : parts) {
+            if (part instanceof PatternContainer patternContainer) {
+                return patternContainer.getTerminalPatternInventory();
+            }
+        }
+        return null;
+    }
+
+    private static void rebuildPatternPage(WidgetGroup patternPage, ItemStackTransfer inventory, int[] page) {
+        patternPage.clearAllWidgets();
+        int startSlot = page[0] * VISIBLE_SLOT_COUNT;
+        int endSlot = Math.min(startSlot + VISIBLE_SLOT_COUNT, SLOT_COUNT);
+        for (int i = startSlot; i < endSlot; i++) {
+            int slotInPage = i - startSlot;
+            int row = slotInPage / COLS;
+            int col = slotInPage % COLS;
+            patternPage.addWidget(new SlotWidget(inventory, i,
+                    LEFT + col * SLOT_SIZE, PATTERN_TOP + row * SLOT_SIZE, true, true)
+                    .setBackgroundTexture(GuiTextures.SLOT)
+                    .setIngredientIO(IngredientIO.INPUT));
+        }
+        patternPage.addWidget(new ButtonWidget(PREVIOUS_PAGE_BUTTON_X, PAGE_BUTTON_Y, PAGE_BUTTON_SIZE, PAGE_BUTTON_SIZE,
+                new GuiTextureGroup(GuiTextures.BUTTON, new TextTexture("<<")), clickData -> {
+                    if (page[0] > 0) {
+                        page[0]--;
+                        rebuildPatternPage(patternPage, inventory, page);
+                    }
+                }));
+        patternPage.addWidget(new LabelWidget(PAGE_LABEL_X, PAGE_LABEL_Y, (page[0] + 1) + " / " + MAX_PAGE));
+        patternPage.addWidget(new ButtonWidget(NEXT_PAGE_BUTTON_X, PAGE_BUTTON_Y, PAGE_BUTTON_SIZE, PAGE_BUTTON_SIZE,
+                new GuiTextureGroup(GuiTextures.BUTTON, new TextTexture(">>")), clickData -> {
+                    if (page[0] < MAX_PAGE - 1) {
+                        page[0]++;
+                        rebuildPatternPage(patternPage, inventory, page);
+                    }
+                }));
+    }
+
     /**
-     * 将供应器内的已编码样板转移到包装箱，直到包装箱装满或供应器取空。
+     * Moves encoded patterns from the target container into the box.
      */
     private static boolean moveProviderToPouch(InternalInventory providerInv, ItemStackTransfer pouchInv) {
         boolean changed = false;
@@ -221,7 +405,7 @@ public class PatternBoxBehavior implements IItemUIFactory {
             }
             int pouchSlot = findEmptyPouchSlot(pouchInv);
             if (pouchSlot < 0) {
-                break; // 包装箱已满
+                break;
             }
             ItemStack extracted = providerInv.extractItem(slot, stack.getCount(), false);
             if (extracted.isEmpty()) {
@@ -234,7 +418,7 @@ public class PatternBoxBehavior implements IItemUIFactory {
     }
 
     /**
-     * 将包装箱内的样板转移到供应器空槽，直到供应器装满或包装箱取空。
+     * Moves compatible patterns from the box into the target container.
      */
     private static boolean movePouchToProvider(ItemStackTransfer pouchInv, InternalInventory providerInv) {
         boolean changed = false;
@@ -243,12 +427,12 @@ public class PatternBoxBehavior implements IItemUIFactory {
             if (stack.isEmpty()) {
                 continue;
             }
-            int providerSlot = findEmptyProviderSlot(providerInv);
+            int providerSlot = findInsertableProviderSlot(providerInv, stack);
             if (providerSlot < 0) {
-                break; // 供应器已满
+                continue;
             }
-            providerInv.setItemDirect(providerSlot, stack.copy());
-            pouchInv.setStackInSlot(slot, ItemStack.EMPTY);
+            ItemStack remainder = providerInv.insertItem(providerSlot, stack.copy(), false);
+            pouchInv.setStackInSlot(slot, remainder);
             changed = true;
         }
         return changed;
@@ -263,9 +447,10 @@ public class PatternBoxBehavior implements IItemUIFactory {
         return -1;
     }
 
-    private static int findEmptyProviderSlot(InternalInventory providerInv) {
+    private static int findInsertableProviderSlot(InternalInventory providerInv, ItemStack stack) {
         for (int slot = 0; slot < providerInv.size(); slot++) {
-            if (providerInv.getStackInSlot(slot).isEmpty()) {
+            if (providerInv.isItemValid(slot, stack) &&
+                    providerInv.insertItem(slot, stack.copy(), true).isEmpty()) {
                 return slot;
             }
         }

--- a/src/main/java/org/gtlcore/gtlcore/forge/ForgeCommonEventListener.java
+++ b/src/main/java/org/gtlcore/gtlcore/forge/ForgeCommonEventListener.java
@@ -3,21 +3,25 @@ package org.gtlcore.gtlcore.forge;
 import org.gtlcore.gtlcore.GTLCore;
 import org.gtlcore.gtlcore.common.data.GTLBlocks;
 import org.gtlcore.gtlcore.common.data.GTLItems;
+import org.gtlcore.gtlcore.common.item.PatternBoxBehavior;
 import org.gtlcore.gtlcore.config.ConfigHolder;
 import org.gtlcore.gtlcore.utils.Registries;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.entity.monster.Shulker;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.EntityTeleportEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.level.BlockEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.common.Mod;
@@ -35,8 +39,17 @@ public class ForgeCommonEventListener {
         event.setCanceled(true);
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
+        if (event.getItemStack().is(GTLItems.PATTERN_BOX.asItem())) {
+            InteractionResult result = PatternBoxBehavior.handleBlockUse(event.getItemStack(),
+                    new UseOnContext(event.getLevel(), event.getEntity(), event.getHand(), event.getItemStack(), event.getHitVec()));
+            if (result != InteractionResult.PASS) {
+                event.setCanceled(true);
+                event.setCancellationResult(result);
+                return;
+            }
+        }
         if (event.getEntity().level().getBlockState(event.getPos()).getBlock() == Blocks.END_PORTAL_FRAME &&
                 event.getEntity().getItemInHand(event.getHand()).getItem() == Items.ENDER_EYE) {
             if (event.getEntity() instanceof ServerPlayer player &&

--- a/src/main/resources/assets/gtlcore/lang/en_us.json
+++ b/src/main/resources/assets/gtlcore/lang/en_us.json
@@ -227,7 +227,7 @@
   "item.gtlcore.miracle_crystal": "§dMiracle Crystal",
   "item.gtlcore.pattern_modifier": "Pattern Provider Modifier",
   "item.gtlcore.pattern_box": "Pattern Box",
-  "tooltip.gtlcore.pattern_box_open": "Right-click in air to open. Stores up to 36 encoded patterns",
+  "tooltip.gtlcore.pattern_box_open": "Right-click in air to open. Stores up to 72 encoded patterns",
   "tooltip.gtlcore.pattern_box_extract": "Right-click a pattern provider / pattern buffer / assembler matrix: pull its patterns into the box",
   "tooltip.gtlcore.pattern_box_insert": "Sneak + right-click a pattern provider / pattern buffer / assembler matrix : push the box's patterns into it",
   "message.gtlcore.pattern_box_extracted": "Pulled patterns from the provider / the buffer / the assembler matrix",


### PR DESCRIPTION
# 修复样板包装箱与终端相关问题

## 变更摘要

- 修复样板包装箱容量与 UI：
  - 容量调整为 72 个已编码样板。
  - UI 保持每页 36 个样板槽，并支持翻页。
  - 英文语言文件同步更新容量说明。
- 修复终端相关 bug：
  - AE 模式下自动搭建不再从玩家背包读取物品或流体。
  - 替换模式下被替换方块优先回存 AE。

## 后续调整

- 调整终极终端 AE 模式材料读取优先级：
  - 开启 AE 模式后，自动搭建优先从绑定的 ME 网络读取物品/流体。
  - ME 网络缺少材料时，继续回退读取玩家背包及其嵌套容器。
  - 开启 AE 模式时，拆除模式和替换模式产生的物品仍然优先回存 ME 网络。
