### PR TITLE
Do not block main server thread during structure detection

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/common/item/StructureDetectBehavior.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/item/StructureDetectBehavior.java
@@ -73,11 +73,14 @@ public class StructureDetectBehavior extends TooltipBehavior implements IToolBeh
                     ((ServerLevel) level).getServer().execute(() -> {
                         var pattern = controller.getPattern();
                         LOCK.lock();
-                        if (LOCK.tryLock()) {
+                        try {
                             var result = check(controller, pattern, isFlipped);
-                            for (var patternError : result) showError(player, patternError, isFlipped);
+                            for (var patternError : result) {
+                                showError(player, patternError, isFlipped);
+                            }
+                        } finally {
                             LOCK.unlock();
-                        } else LOCK.unlock();
+                        }
                     });
                     return InteractionResult.SUCCESS;
                 }

--- a/src/main/java/org/gtlcore/gtlcore/common/item/StructureDetectBehavior.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/item/StructureDetectBehavior.java
@@ -72,7 +72,10 @@ public class StructureDetectBehavior extends TooltipBehavior implements IToolBeh
                     boolean isFlipped = !tag.isEmpty() && tag.getBoolean("isFlipped");
                     ((ServerLevel) level).getServer().execute(() -> {
                         var pattern = controller.getPattern();
-                        LOCK.lock();
+                        if (!LOCK.tryLock()) {
+                            player.sendSystemMessage(Component.literal("Structure detection is already running."));
+                            return;
+                        }
                         try {
                             var result = check(controller, pattern, isFlipped);
                             for (var patternError : result) {


### PR DESCRIPTION
## Summary
- cherry-pick the structure-detect locking fix onto `gtl-1431-skyblock`
- release the lock in a `finally` block
- move the potentially blocking work off the main server thread

## Why
The original fix was opened against the non-skyblock branch. This targets the current skyblock release line (`1.2.3.0-fix7`) instead.

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) http_proxy=http://localhost:1087 https_proxy=http://localhost:1087 HTTP_PROXY=http://localhost:1087 HTTPS_PROXY=http://localhost:1087 ./gradlew --no-daemon -Dhttp.proxyHost=localhost -Dhttp.proxyPort=1087 -Dhttps.proxyHost=localhost -Dhttps.proxyPort=1087 assemble`
