### PR TITLE
Revert "fix: 修复大量使用库存仓室时，退出游戏可能卡死在“保存世界中”的问题" 暂时回滚，寻找更安全的修复方案

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/machine/MetaMachineMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/machine/MetaMachineMixin.java
@@ -11,14 +11,10 @@ import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.TickableSubscription;
 import com.gregtechceu.gtceu.integration.ae2.machine.feature.IGridConnectedMachine;
-import com.lowdragmc.lowdraglib.async.AsyncThreadData;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.TickTask;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -35,7 +31,6 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.EnumSet;
@@ -65,9 +60,6 @@ public abstract class MetaMachineMixin implements IPerformanceDisplayMachine, IS
 
     @Unique
     private boolean gtlcore$suspendAfterFinish;
-
-    @Unique
-    private volatile boolean gtlcore$queuedAsyncChanged;
 
     @Shadow(remap = false)
     public abstract boolean isRemote();
@@ -104,27 +96,6 @@ public abstract class MetaMachineMixin implements IPerformanceDisplayMachine, IS
 
     @Shadow(remap = false)
     public abstract void onChanged();
-
-    @Inject(method = "onChanged", at = @At("HEAD"), cancellable = true, remap = false)
-    private void gtlcore$moveAsyncOnChangedToServerThread(CallbackInfo ci) {
-        Level level = getLevel();
-        if (!(level instanceof ServerLevel serverLevel)) return;
-        MinecraftServer server = serverLevel.getServer();
-        if (server.isSameThread()) return;
-        if (!AsyncThreadData.isThreadService()) return;
-        ci.cancel();
-        if (gtlcore$queuedAsyncChanged || isInValid()) return;
-        gtlcore$queuedAsyncChanged = true;
-        server.tell(new TickTask(server.getTickCount(), () -> {
-            try {
-                if (!isInValid()) {
-                    onChanged();
-                }
-            } finally {
-                gtlcore$queuedAsyncChanged = false;
-            }
-        }));
-    }
 
     @Override
     public int gtlcore$getTickTime() {


### PR DESCRIPTION
Reverts AaAdoniSsS/GTLCore#58
尝试更换更安全的方案修复