### PR TITLE
fix: 尝试修复机器使用库存ME样板总成时偶现的配方检测未更新的问题

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/ae/MEStockingPatternBufferPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/ae/MEStockingPatternBufferPartMachine.java
@@ -199,6 +199,36 @@ public class MEStockingPatternBufferPartMachine extends MEPatternBufferPartMachi
     }
 
     protected void syncStockInput() {
+        // No active pattern slots means no recipe can currently run here or in bound proxies.
+        // Sync stock for the UI, but skip the expensive before/after comparison and notification.
+        if (!hasActiveSlot()) {
+            performStockSync();
+            return;
+        }
+
+        var oldItemStock = new Object2LongOpenHashMap<>(stockItemHandler.stockMap);
+        var oldFluidStock = new Object2LongOpenHashMap<>(stockFluidHandler.stockMap);
+
+        performStockSync();
+
+        boolean changed = !oldItemStock.equals(stockItemHandler.stockMap) || !oldFluidStock.equals(stockFluidHandler.stockMap);
+        if (changed) {
+            recipeHandler.getMeItemHandler().notifyListeners();
+            recipeHandler.getMeFluidHandler().notifyListeners();
+        }
+    }
+
+    private boolean hasActiveSlot() {
+        int count = getInternalSlotCount();
+        for (int i = 0; i < count; i++) {
+            if (getInternalSlot(i).isActive()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void performStockSync() {
         IGrid grid = this.getMainNode().getGrid();
         if (grid == null) {
             stockItemHandler.clearStocks();


### PR DESCRIPTION
修复了库存ME样板总成 stocking 输入同步后，recipe handler 监听器未被通知的问题：

- 当 stocking 物品/流体数量变化时，会通知 item/fluid recipe handler，使机器能够及时感知库存处的原料变化并重新检查配方，防止出现 stocking 从原料不足到补充后，机器未重新检测配方而仍不运行的情况；

- 当没有任何激活样板槽时，跳过前后对比和通知以节省性能，因为 stocking 输入本身不会单独触发配方检测。