### PR TITLE
fix: 修复电力聚爆压缩机、中子漩涡、进阶真空干燥炉实际运行逻辑使其更符合tooltips描述

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/common/data/machines/AdditionalMultiBlockMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/data/machines/AdditionalMultiBlockMachine.java
@@ -271,7 +271,9 @@ public class AdditionalMultiBlockMachine {
                 recipe.tickInputs.put(EURecipeCapability.CAP,
                         List.of(new Content(eu, 10000, 10000, 0, null, null)));
                 ((IGTRecipe) recipe).setHasTick(true);
-                return GTRecipeModifiers.hatchParallel(machine, recipe, false, params, result);
+                int parallel = GTLRecipeModifiers.getHatchParallel(machine);
+                result.init(eu, recipe.duration, parallel, params.getOcAmount());
+                return recipe;
             }))
             .appearanceBlock(GTLBlocks.SPS_CASING)
             .pattern(definition -> FactoryBlockPattern.start()

--- a/src/main/java/org/gtlcore/gtlcore/common/data/machines/AdditionalMultiBlockMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/data/machines/AdditionalMultiBlockMachine.java
@@ -116,13 +116,23 @@ public class AdditionalMultiBlockMachine {
             .appearanceBlock(GTBlocks.HIGH_POWER_CASING)
             .recipeModifiers((machine, recipe, params, result) -> {
                 if (machine instanceof CoilWorkableElectricMultiblockMachine coilMachine) {
-                    GTRecipe recipe1 = GTRecipeModifiers.accurateParallel(coilMachine, recipe, (int) Math.min(2147483647, Math.pow(2, coilMachine.getCoilType().getCoilTemperature() / 900D)), false).getFirst();
-                    if (recipe1 != null) {
-                        return RecipeHelper.applyOverclock(OverclockingLogic.NON_PERFECT_OVERCLOCK_SUBTICK, recipe1, coilMachine.getOverclockVoltage(), params, result);
+                    // 0.5 耗时倍率在并行之先应用，与其他带固定耗时倍率的机器保持一致
+                    recipe.duration = (int) Math.max(1, recipe.duration * 0.5);
+
+                    int parallel = (int) Math.min(2147483647,
+                            Math.pow(2, coilMachine.getCoilType().getCoilTemperature() / 900D));
+                    GTRecipe recipe1 = GTRecipeModifiers.accurateParallel(coilMachine, recipe, parallel, false).getFirst();
+                    if (recipe1 == null) return null;
+
+                    if (recipe1.data.contains("ebf_temp")) {
+                        return GTRecipeModifiers.ebfOverclock(coilMachine, recipe1, params, result);
+                    } else {
+                        return RecipeHelper.applyOverclock(OverclockingLogic.PERFECT_OVERCLOCK_SUBTICK, recipe1,
+                                coilMachine.getOverclockVoltage(), params, result);
                     }
                 }
                 return null;
-            }, (machine, recipe, params, result) -> GTLRecipeModifiers.reduction(machine, recipe, 1, 0.5))
+            })
             .pattern(definition -> FactoryBlockPattern.start()
                     .aisle("          AAAAAAA  ", "   BBBBBBBBBBBBBB  ", "   B         C     ", "           CCCCC   ", "          CCCCCCC  ", "         CCCCCCCCC ", "         CCCDDDCCC ", "        CCCCDDDCCCC", "         CCCDDDCCC ", "         CCCCCCCCC ", "          CCCCCCC  ", "           CCCCC   ", "             C     ", "                   ")
                     .aisle("CCCCCCC   A CCC A  ", "  GGG       CCC B  ", "  GBG      FFFFF   ", "  GGG     FFFFFFF  ", "  GGG    FFFFFFFFF ", "  GGG   FFFFFFFFFFF", "  GGG   FFFFFFFFFFF", "  GGG   FFFFFFFFFFF", "  GGG   FFFFFFFFFFF", "   C    FFFFFFFFFFF", "         FFFFFFFFF ", "          FFFFFFF  ", "           FFFFF   ", "                   ")

--- a/src/main/java/org/gtlcore/gtlcore/common/data/machines/MultiBlockMachineA.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/data/machines/MultiBlockMachineA.java
@@ -3094,7 +3094,8 @@ public class MultiBlockMachineA {
             .tooltipBuilder(GTLMachines.GTL_ADD)
             .rotationState(RotationState.ALL)
             .recipeType(GTLRecipeTypes.ELECTRIC_IMPLOSION_COMPRESSOR_RECIPES)
-            .recipeModifiers(GTRecipeModifiers.PARALLEL_HATCH,
+            .recipeModifiers(GTLRecipeModifiers.GCYM_REDUCTION,
+                    GTRecipeModifiers.PARALLEL_HATCH,
                     GTRecipeModifiers.ELECTRIC_OVERCLOCK.apply(OverclockingLogic.NON_PERFECT_OVERCLOCK_SUBTICK))
             .appearanceBlock(GTBlocks.CASING_TUNGSTENSTEEL_ROBUST)
             .pattern(definition -> FactoryBlockPattern.start()


### PR DESCRIPTION
 -修复电力聚爆压缩机的 GCYM 耗能耗时减免未正常生效的问题
 -修复中子漩涡运行配方时并行重复计算的问题
 -将进阶真空干燥炉的耗时倍数在并行前应用，以与其他机器的计算顺序保持一致
 -尝试修复进阶真空干燥炉未正确应用无损超频与线圈耗能减免的问题：修复前使用普通超频，此次修复仅为 ebf_temp 配方即真空干燥使用了 ebfOverclock ，脱水配方仅应用 PERFECT_OC 