### PR TITLE
fix(ae2): 修复样板供应器智能翻倍的多材料发配

### DIFF
--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -75,6 +75,7 @@
     "gtlcore:component_assembly_line_casing_uxv",
     "gtlcore:component_assembly_line_casing_opv",
     "gtlcore:component_assembly_line_casing_max",
-    "gtlcore:wireless_network_core"
+    "gtlcore:wireless_network_core",
+    "gtlcore:wireless_network_bookmark"
   ]
 }

--- a/src/generated/resources/data/minecraft/tags/blocks/needs_diamond_tool.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/needs_diamond_tool.json
@@ -2,6 +2,7 @@
   "values": [
     "gtlcore:fusion_casing_mk4",
     "gtlcore:fusion_casing_mk5",
-    "gtlcore:wireless_network_core"
+    "gtlcore:wireless_network_core",
+    "gtlcore:wireless_network_bookmark"
   ]
 }

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/CraftingPatternAutoExpand.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/CraftingPatternAutoExpand.java
@@ -4,6 +4,7 @@ import org.gtlcore.gtlcore.api.machine.trait.AECraft.IMECraftIOPart;
 import org.gtlcore.gtlcore.api.machine.trait.MEPart.IMEPatternPartMachine;
 import org.gtlcore.gtlcore.config.ConfigHolder;
 
+import appeng.api.crafting.IPatternDetails;
 import appeng.api.networking.crafting.ICraftingProvider;
 import appeng.helpers.patternprovider.PatternProviderLogic;
 
@@ -19,6 +20,18 @@ public final class CraftingPatternAutoExpand {
             return true;
         }
         return isPatternProviderAutoExpandEnabled() && provider instanceof PatternProviderLogic;
+    }
+
+    public static long getOperations(boolean processingPattern, ICraftingProvider provider,
+                                     IPatternDetails pattern, long requestedOperations) {
+        if (!canAutoExpand(processingPattern, provider) || requestedOperations <= 0) {
+            return 1;
+        }
+        if (provider instanceof IPatternProviderAutoExpand capacityProvider) {
+            return Math.max(1, Math.min(requestedOperations,
+                    capacityProvider.gtlcore$getMaxPatternOperations(pattern, requestedOperations)));
+        }
+        return requestedOperations;
     }
 
     private static boolean isPatternProviderAutoExpandEnabled() {

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/IPatternProviderAutoExpand.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/IPatternProviderAutoExpand.java
@@ -1,0 +1,8 @@
+package org.gtlcore.gtlcore.integration.ae2.crafting;
+
+import appeng.api.crafting.IPatternDetails;
+
+public interface IPatternProviderAutoExpand {
+
+    long gtlcore$getMaxPatternOperations(IPatternDetails pattern, long requestedOperations);
+}

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessNetworkBookmarkBlock.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/wireless/WirelessNetworkBookmarkBlock.java
@@ -36,7 +36,8 @@ public class WirelessNetworkBookmarkBlock extends BaseEntityBlock {
     public WirelessNetworkBookmarkBlock() {
         super(BlockBehaviour.Properties.of()
                 .mapColor(MapColor.COLOR_LIGHT_BLUE)
-                .strength(3.0F));
+                .strength(3.0F)
+                .requiresCorrectToolForDrops());
         registerDefaultState(stateDefinition.any().setValue(FACING, Direction.NORTH));
     }
 

--- a/src/main/java/org/gtlcore/gtlcore/mixin/ae2/logic/CraftingCpuLogicMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/ae2/logic/CraftingCpuLogicMixin.java
@@ -204,8 +204,10 @@ public abstract class CraftingCpuLogicMixin implements ICraftingJobSuspension, I
                 idleProviderSeen = true;
 
                 final boolean autoExpand = CraftingPatternAutoExpand.canAutoExpand(isProcessing, provider);
+                final long operations = CraftingPatternAutoExpand.getOperations(isProcessing, provider, details,
+                        taskProgress.getValue());
                 KeyCounter expectedOutputs = new KeyCounter(), expectedContainerItems = new KeyCounter();
-                KeyCounter[] craftingContainer = isProcessing ? (autoExpand ? AEUtils.extractForProcessingPattern((AEProcessingPattern) details, inventory, expectedOutputs, taskProgress.getValue()) : AEUtils.extractForProcessingPattern((AEProcessingPattern) details, inventory, expectedOutputs)) : AEUtils.extractForCraftPattern(details, inventory, level, expectedOutputs, expectedContainerItems);
+                KeyCounter[] craftingContainer = isProcessing ? (autoExpand ? AEUtils.extractForProcessingPattern((AEProcessingPattern) details, inventory, expectedOutputs, operations) : AEUtils.extractForProcessingPattern((AEProcessingPattern) details, inventory, expectedOutputs)) : AEUtils.extractForCraftPattern(details, inventory, level, expectedOutputs, expectedContainerItems);
 
                 if (craftingContainer == null) {
                     taskReasonMask |= CraftingDispatchReason.WAITING_FOR_INPUTS.mask();
@@ -213,7 +215,7 @@ public abstract class CraftingCpuLogicMixin implements ICraftingJobSuspension, I
                 }
 
                 var patternPower = CraftingPatternPower.forCpu(CraftingCpuHelper.calculatePatternPower(craftingContainer),
-                        autoExpand, taskProgress.getValue());
+                        autoExpand, operations);
                 if (energyService.extractAEPower(patternPower, Actionable.SIMULATE, PowerMultiplier.CONFIG) < patternPower - 0.01) {
                     CraftingCpuHelper.reinjectPatternInputs(inventory, craftingContainer);
                     taskReasonMask |= CraftingDispatchReason.INSUFFICIENT_POWER.mask();
@@ -240,9 +242,16 @@ public abstract class CraftingCpuLogicMixin implements ICraftingJobSuspension, I
 
                     // 1) AutoExpand
                     if (autoExpand) {
-                        taskProgress.setValue(0);
-                        it.remove();
-                        this.gtlcore$workingDispatchReasons.remove(details);
+                        taskProgress.setValue(taskProgress.getValue() - operations);
+                        if (taskProgress.getValue() <= 0) {
+                            it.remove();
+                            this.gtlcore$workingDispatchReasons.remove(details);
+                            continue taskLoop;
+                        }
+                        if (pushedPatterns == maxPatterns) {
+                            gtlcore$markAllUnclassified(CraftingDispatchReason.CPU_OPERATION_LIMIT);
+                            break taskLoop;
+                        }
                         continue taskLoop;
                     }
 

--- a/src/main/java/org/gtlcore/gtlcore/mixin/ae2/logic/PatternProviderLogicMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/ae2/logic/PatternProviderLogicMixin.java
@@ -1,12 +1,22 @@
 package org.gtlcore.gtlcore.mixin.ae2.logic;
 
+import org.gtlcore.gtlcore.integration.ae2.crafting.IPatternProviderAutoExpand;
+import org.gtlcore.gtlcore.utils.NumberUtils;
+
 import com.gregtechceu.gtceu.common.data.GTItems;
 
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+
 import appeng.api.config.Actionable;
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.implementations.blockentities.ICraftingMachine;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
+import appeng.api.stacks.AEKeyType;
 import appeng.api.stacks.KeyCounter;
 import appeng.helpers.patternprovider.PatternProviderLogic;
+import appeng.helpers.patternprovider.PatternProviderLogicHost;
 import appeng.helpers.patternprovider.PatternProviderTarget;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -16,17 +26,38 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * @author EasterFG on 2024/10/13
  */
 @Mixin(PatternProviderLogic.class)
-public abstract class PatternProviderLogicMixin {
+public abstract class PatternProviderLogicMixin implements IPatternProviderAutoExpand {
+
+    @Shadow(remap = false)
+    @Final
+    private PatternProviderLogicHost host;
 
     @Shadow(remap = false)
     @Final
     private Set<AEKey> patternInputs;
+
+    @Shadow(remap = false)
+    private Set<Direction> getActiveSides() {
+        throw new AssertionError();
+    }
+
+    @Shadow(remap = false)
+    private PatternProviderTarget findAdapter(Direction direction) {
+        throw new AssertionError();
+    }
+
+    @Shadow(remap = false)
+    private boolean isBlocking() {
+        throw new AssertionError();
+    }
 
     @Inject(method = "updatePatterns", at = @At("TAIL"), remap = false)
     public void updatePatternsHook(CallbackInfo ci) {
@@ -36,20 +67,112 @@ public abstract class PatternProviderLogicMixin {
     @Inject(method = "adapterAcceptsAll", at = @At("HEAD"), remap = false, cancellable = true)
     private void gtlcore$requireFullTargetCapacity(PatternProviderTarget target, KeyCounter[] inputHolder,
                                                    CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(gtlcore$targetAcceptsAll(target, gtlcore$toInputCounter(inputHolder), 1));
+    }
+
+    @Override
+    public long gtlcore$getMaxPatternOperations(IPatternDetails pattern, long requestedOperations) {
+        if (requestedOperations <= 1 || !pattern.supportsPushInputsToExternalInventory()) {
+            return requestedOperations;
+        }
+
+        var blockEntity = host.getBlockEntity();
+        Level level = blockEntity.getLevel();
+        if (level == null) {
+            return requestedOperations;
+        }
+
+        var baseInputs = gtlcore$toInputCounter(pattern);
+        long maxOperations = 0;
+        boolean hasAdapter = false;
+
+        for (var direction : getActiveSides()) {
+            var targetPosition = blockEntity.getBlockPos().relative(direction);
+            var targetBlockEntity = level.getBlockEntity(targetPosition);
+            var machine = ICraftingMachine.of(level, targetPosition, direction.getOpposite(), targetBlockEntity);
+            if (machine != null && machine.acceptsPlans()) {
+                return requestedOperations;
+            }
+
+            var target = findAdapter(direction);
+            if (target == null || (isBlocking() && target.containsPatternInput(patternInputs))) {
+                continue;
+            }
+            hasAdapter = true;
+            maxOperations = Math.max(maxOperations,
+                    gtlcore$findMaxOperations(target, baseInputs, requestedOperations));
+        }
+
+        if (!hasAdapter) {
+            return requestedOperations;
+        }
+        return maxOperations;
+    }
+
+    private long gtlcore$findMaxOperations(PatternProviderTarget target, KeyCounter baseInputs,
+                                           long requestedOperations) {
+        if (!gtlcore$targetAcceptsAll(target, baseInputs, requestedOperations)) {
+            // Target acceptance is monotonic with batch size, so find the largest feasible batch.
+            long low = 0;
+            long high = requestedOperations - 1;
+            while (low < high) {
+                long middle = low + ((high - low + 1) >>> 1);
+                if (gtlcore$targetAcceptsAll(target, baseInputs, middle)) {
+                    low = middle;
+                } else {
+                    high = middle - 1;
+                }
+            }
+            return low;
+        }
+        return requestedOperations;
+    }
+
+    private boolean gtlcore$targetAcceptsAll(PatternProviderTarget target, KeyCounter baseInputs,
+                                             long operations) {
+        Map<AEKeyType, Long> requiredByType = new IdentityHashMap<>();
+        Map<AEKeyType, Long> capacityByType = new IdentityHashMap<>();
+        for (var input : baseInputs) {
+            long amount = NumberUtils.saturatedMultiply(input.getLongValue(), operations);
+            if (amount <= 0) {
+                continue;
+            }
+
+            AEKeyType type = input.getKey().getType();
+            long available = target.insert(input.getKey(), Long.MAX_VALUE, Actionable.SIMULATE);
+            requiredByType.merge(type, amount, NumberUtils::saturatedAdd);
+            capacityByType.merge(type, available, Long::min);
+        }
+
+        // SIMULATE calls do not reserve shared slots. Use the smallest per-key capacity
+        // as a conservative shared-capacity bound so one input cannot consume the batch.
+        for (var entry : requiredByType.entrySet()) {
+            if (entry.getValue() > capacityByType.getOrDefault(entry.getKey(), 0L)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private KeyCounter gtlcore$toInputCounter(KeyCounter[] inputHolder) {
         var combinedInputs = new KeyCounter();
         for (var inputList : inputHolder) {
             for (var input : inputList) {
                 combinedInputs.add(input.getKey(), input.getLongValue());
             }
         }
+        return combinedInputs;
+    }
 
-        for (var input : combinedInputs) {
-            long amount = input.getLongValue();
-            if (target.insert(input.getKey(), amount, Actionable.SIMULATE) != amount) {
-                cir.setReturnValue(false);
-                return;
+    private KeyCounter gtlcore$toInputCounter(IPatternDetails pattern) {
+        var baseInputs = new KeyCounter();
+        for (var input : pattern.getInputs()) {
+            var possibleInputs = input.getPossibleInputs();
+            if (possibleInputs.length == 0) {
+                continue;
             }
+            baseInputs.add(possibleInputs[0].what(), input.getMultiplier());
         }
-        cir.setReturnValue(true);
+        return baseInputs;
     }
 }


### PR DESCRIPTION
## 摘要

修复 AE2 样板供应器智能翻倍在多材料处理样板下的发配问题，避免第一种材料占满共享容器，导致其他材料无法按比例输入。

## 变更内容

- 新增样板供应器批量操作数量查询接口。
- 根据目标容器容量动态计算最大翻倍批次。
- 按 `AEKeyType` 合并材料需求并检查共享容量。
- 保证多材料输入按照样板原始比例发配。
- 修复批量发配后的任务进度扣减，容量不足时保留剩余任务。
- 同步调整批量输入、输出和能耗计算。
- 为无线网络收藏器增加正确工具挖掘要求。
- 更新无线网络收藏器的镐类和钻石工具标签。
