### PR TITLE
feat(ae2): 新增样板供应器的智能翻倍功能对样板p2p的适配

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/AEUtils.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/AEUtils.java
@@ -280,13 +280,13 @@ public class AEUtils {
         }
     }
 
-    public static KeyCounter[] extractForProcessingPattern(AEProcessingPattern originDetail,
+    public static KeyCounter[] extractForProcessingPattern(IPatternDetails originDetail,
                                                            ICraftingInventory sourceInv,
                                                            KeyCounter expectedOutputs) {
         return extractForProcessingPattern(originDetail, sourceInv, expectedOutputs, 1);
     }
 
-    public static KeyCounter[] extractForProcessingPattern(AEProcessingPattern originDetail,
+    public static KeyCounter[] extractForProcessingPattern(IPatternDetails originDetail,
                                                            ICraftingInventory sourceInv,
                                                            KeyCounter expectedOutputs,
                                                            long multiplier) {

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/compat/MAE2Compat.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/compat/MAE2Compat.java
@@ -1,0 +1,178 @@
+package org.gtlcore.gtlcore.integration.ae2.compat;
+
+import org.gtlcore.gtlcore.integration.ae2.crafting.IPatternProviderAutoExpand;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.implementations.blockentities.ICraftingMachine;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.KeyCounter;
+import appeng.helpers.patternprovider.PatternProviderTarget;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+
+public final class MAE2Compat {
+
+    private static final Logger LOGGER = LogManager.getLogger(MAE2Compat.class);
+
+    private static final String PATTERN_P2P_TUNNEL_LOGIC = "stone.mae2.parts.p2p.PatternP2PTunnelLogic";
+    private static final String PATTERN_P2P_TUNNEL = "stone.mae2.parts.p2p.PatternP2PTunnelLogic$PatternP2PTunnel";
+    private static final String PATTERN_P2P_TARGET = "stone.mae2.parts.p2p.PatternP2PTunnelLogic$Target";
+    private static final String PATTERN_PROVIDER_TARGET_CACHE = "stone.mae2.appeng.helpers.patternprovider.PatternProviderTargetCache";
+
+    @Nullable
+    private static final Class<?> PATTERN_P2P_TUNNEL_LOGIC_CLASS = loadClass(PATTERN_P2P_TUNNEL_LOGIC);
+    @Nullable
+    private static final Class<?> PATTERN_P2P_TUNNEL_CLASS = loadClass(PATTERN_P2P_TUNNEL);
+    @Nullable
+    private static final Class<?> PATTERN_P2P_TARGET_CLASS = loadClass(PATTERN_P2P_TARGET);
+    @Nullable
+    private static final Class<?> PATTERN_PROVIDER_TARGET_CACHE_CLASS = loadClass(PATTERN_PROVIDER_TARGET_CACHE);
+
+    @Nullable
+    private static final Field P2P_TUNNEL_FIELD = getDeclaredField(PATTERN_P2P_TUNNEL_LOGIC_CLASS, "tunnel");
+
+    @Nullable
+    private static final Method TUNNEL_GET_OUTPUTS = getMethod(PATTERN_P2P_TUNNEL_CLASS, "getPatternTunnelOutputs");
+    @Nullable
+    private static final Method TARGET_IS_VALID = getMethod(PATTERN_P2P_TARGET_CLASS, "isValid");
+    @Nullable
+    private static final Method TARGET_LEVEL = getMethod(PATTERN_P2P_TARGET_CLASS, "level");
+    @Nullable
+    private static final Method TARGET_POS = getMethod(PATTERN_P2P_TARGET_CLASS, "pos");
+    @Nullable
+    private static final Method TARGET_SIDE = getMethod(PATTERN_P2P_TARGET_CLASS, "side");
+    @Nullable
+    private static final Method TARGET_GET_CACHE = getMethod(PATTERN_P2P_TARGET_CLASS, "getCache");
+    @Nullable
+    private static final Method CACHE_FIND = getMethod(PATTERN_PROVIDER_TARGET_CACHE_CLASS, "find");
+
+    private MAE2Compat() {}
+
+    public static boolean isPatternP2PTunnelLogic(Object machine) {
+        return PATTERN_P2P_TUNNEL_LOGIC_CLASS != null && PATTERN_P2P_TUNNEL_LOGIC_CLASS.isInstance(machine);
+    }
+
+    public static long getPatternP2PMaxOperations(Object machine, IPatternDetails pattern, long requestedOperations,
+                                                  Level level, KeyCounter baseInputs, boolean blocking,
+                                                  Set<AEKey> patternInputs,
+                                                  IPatternProviderAutoExpand capacityProvider) {
+        if (!isPatternP2PTunnelLogic(machine) || requestedOperations <= 1 || !pattern.supportsPushInputsToExternalInventory()) {
+            return requestedOperations;
+        }
+
+        if (P2P_TUNNEL_FIELD == null || TUNNEL_GET_OUTPUTS == null) {
+            return requestedOperations;
+        }
+
+        try {
+            Object tunnel = P2P_TUNNEL_FIELD.get(machine);
+            if (tunnel == null) {
+                return requestedOperations;
+            }
+
+            List<?> outputs = (List<?>) TUNNEL_GET_OUTPUTS.invoke(tunnel);
+            if (outputs == null || outputs.isEmpty()) {
+                return 1;
+            }
+
+            long minOperations = Long.MAX_VALUE;
+            boolean anyValid = false;
+
+            for (Object output : outputs) {
+                if (output == null) {
+                    continue;
+                }
+                if (!Boolean.TRUE.equals(TARGET_IS_VALID.invoke(output))) {
+                    continue;
+                }
+                anyValid = true;
+
+                ServerLevel outputLevel = (ServerLevel) TARGET_LEVEL.invoke(output);
+                BlockPos outputPos = (BlockPos) TARGET_POS.invoke(output);
+                Direction outputSide = (Direction) TARGET_SIDE.invoke(output);
+                BlockEntity outputBE = outputLevel.getBlockEntity(outputPos);
+
+                long outputOperations;
+                ICraftingMachine craftingMachine = ICraftingMachine.of(outputLevel, outputPos, outputSide, outputBE);
+                if (craftingMachine != null && craftingMachine.acceptsPlans()) {
+                    outputOperations = requestedOperations;
+                } else {
+                    Object cache = TARGET_GET_CACHE.invoke(output);
+                    if (cache == null) {
+                        continue;
+                    }
+                    PatternProviderTarget target = (PatternProviderTarget) CACHE_FIND.invoke(cache);
+                    if (target == null) {
+                        continue;
+                    }
+                    if (blocking && target.containsPatternInput(patternInputs)) {
+                        // This output is currently blocked; the P2P tunnel will skip it when
+                        // routing, so do not count it toward the minimum capacity.
+                        continue;
+                    }
+                    outputOperations = capacityProvider.gtlcore$findMaxOperationsForTarget(
+                            target, outputBE, outputSide, baseInputs, requestedOperations);
+                }
+
+                if (outputOperations < minOperations) {
+                    minOperations = outputOperations;
+                }
+            }
+
+            if (!anyValid || minOperations == Long.MAX_VALUE) {
+                return 1;
+            }
+            return Math.max(1, minOperations);
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to compute MAE2 pattern P2P max operations", t);
+            return 1;
+        }
+    }
+
+    @Nullable
+    private static Class<?> loadClass(String className) {
+        try {
+            return Class.forName(className, false, MAE2Compat.class.getClassLoader());
+        } catch (ClassNotFoundException | LinkageError ignored) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Field getDeclaredField(@Nullable Class<?> clazz, String name) {
+        if (clazz == null) {
+            return null;
+        }
+        try {
+            Field field = clazz.getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
+        } catch (NoSuchFieldException | LinkageError ignored) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Method getMethod(@Nullable Class<?> clazz, String name, Class<?>... parameterTypes) {
+        if (clazz == null) {
+            return null;
+        }
+        try {
+            return clazz.getMethod(name, parameterTypes);
+        } catch (NoSuchMethodException | LinkageError ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/IPatternProviderAutoExpand.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/IPatternProviderAutoExpand.java
@@ -1,8 +1,16 @@
 package org.gtlcore.gtlcore.integration.ae2.crafting;
 
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
 import appeng.api.crafting.IPatternDetails;
+import appeng.api.stacks.KeyCounter;
+import appeng.helpers.patternprovider.PatternProviderTarget;
 
 public interface IPatternProviderAutoExpand {
 
     long gtlcore$getMaxPatternOperations(IPatternDetails pattern, long requestedOperations);
+
+    long gtlcore$findMaxOperationsForTarget(PatternProviderTarget target, BlockEntity targetBE, Direction side,
+                                            KeyCounter baseInputs, long requestedOperations);
 }

--- a/src/main/java/org/gtlcore/gtlcore/mixin/ae2/logic/CraftingCpuLogicMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/ae2/logic/CraftingCpuLogicMixin.java
@@ -23,7 +23,6 @@ import appeng.crafting.execution.CraftingCpuHelper;
 import appeng.crafting.execution.CraftingCpuLogic;
 import appeng.crafting.execution.ExecutingCraftingJob;
 import appeng.crafting.inv.ListCraftingInventory;
-import appeng.crafting.pattern.AEProcessingPattern;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import appeng.me.service.CraftingService;
 import org.jetbrains.annotations.Nullable;
@@ -190,7 +189,7 @@ public abstract class CraftingCpuLogicMixin implements ICraftingJobSuspension, I
             }
 
             var details = task.getKey();
-            final boolean isProcessing = details instanceof AEProcessingPattern;
+            final boolean isProcessing = details.supportsPushInputsToExternalInventory();
             boolean providerSeen = false;
             boolean idleProviderSeen = false;
             boolean providerRejected = false;
@@ -207,7 +206,7 @@ public abstract class CraftingCpuLogicMixin implements ICraftingJobSuspension, I
                 final long operations = CraftingPatternAutoExpand.getOperations(isProcessing, provider, details,
                         taskProgress.getValue());
                 KeyCounter expectedOutputs = new KeyCounter(), expectedContainerItems = new KeyCounter();
-                KeyCounter[] craftingContainer = isProcessing ? (autoExpand ? AEUtils.extractForProcessingPattern((AEProcessingPattern) details, inventory, expectedOutputs, operations) : AEUtils.extractForProcessingPattern((AEProcessingPattern) details, inventory, expectedOutputs)) : AEUtils.extractForCraftPattern(details, inventory, level, expectedOutputs, expectedContainerItems);
+                KeyCounter[] craftingContainer = isProcessing ? (autoExpand ? AEUtils.extractForProcessingPattern(details, inventory, expectedOutputs, operations) : AEUtils.extractForProcessingPattern(details, inventory, expectedOutputs)) : AEUtils.extractForCraftPattern(details, inventory, level, expectedOutputs, expectedContainerItems);
 
                 if (craftingContainer == null) {
                     taskReasonMask |= CraftingDispatchReason.WAITING_FOR_INPUTS.mask();

--- a/src/main/java/org/gtlcore/gtlcore/mixin/ae2/logic/PatternProviderLogicMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/ae2/logic/PatternProviderLogicMixin.java
@@ -2,6 +2,7 @@ package org.gtlcore.gtlcore.mixin.ae2.logic;
 
 import org.gtlcore.gtlcore.api.crafting.IAutoExpandSettings;
 import org.gtlcore.gtlcore.config.ConfigHolder;
+import org.gtlcore.gtlcore.integration.ae2.compat.MAE2Compat;
 import org.gtlcore.gtlcore.integration.ae2.crafting.IPatternProviderAutoExpand;
 import org.gtlcore.gtlcore.utils.NumberUtils;
 
@@ -177,14 +178,29 @@ public abstract class PatternProviderLogicMixin implements IAutoExpandSettings, 
 
         var baseInputs = gtlcore$toInputCounter(pattern);
         long maxOperations = 0;
+        long p2pMaxOperations = Long.MAX_VALUE;
         boolean hasAdapter = false;
+        boolean hasP2PTunnel = false;
+        boolean hasUnlimitedMachine = false;
 
         for (var direction : getActiveSides()) {
             var targetPosition = blockEntity.getBlockPos().relative(direction);
             var targetBlockEntity = level.getBlockEntity(targetPosition);
             var machine = ICraftingMachine.of(level, targetPosition, direction.getOpposite(), targetBlockEntity);
             if (machine != null && machine.acceptsPlans()) {
-                return requestedOperations;
+                if (MAE2Compat.isPatternP2PTunnelLogic(machine)) {
+                    // MAE2 pattern P2P tunnels route one whole batch to a single output.
+                    // The safe expansion is therefore limited by the smallest capacity among
+                    // all of the tunnel's outputs. Because the provider may select this side
+                    // before any other active side, we cap the global operation count by it.
+                    hasP2PTunnel = true;
+                    p2pMaxOperations = Math.min(p2pMaxOperations,
+                            MAE2Compat.getPatternP2PMaxOperations(machine, pattern, requestedOperations,
+                                    level, baseInputs, isBlocking(), patternInputs, this));
+                } else {
+                    hasUnlimitedMachine = true;
+                }
+                continue;
             }
 
             var target = findAdapter(direction);
@@ -197,10 +213,25 @@ public abstract class PatternProviderLogicMixin implements IAutoExpandSettings, 
                             baseInputs, requestedOperations));
         }
 
-        if (!hasAdapter) {
+        if (hasUnlimitedMachine && !hasP2PTunnel) {
             return requestedOperations;
         }
-        return Math.max(maxOperations, 1);
+
+        if (!hasAdapter && !hasP2PTunnel) {
+            return requestedOperations;
+        }
+
+        long result = hasP2PTunnel ? p2pMaxOperations : maxOperations;
+        if (hasP2PTunnel && hasAdapter) {
+            result = Math.min(result, maxOperations);
+        }
+        return Math.max(1, result);
+    }
+
+    @Override
+    public long gtlcore$findMaxOperationsForTarget(PatternProviderTarget target, BlockEntity targetBE, Direction side,
+                                                   KeyCounter baseInputs, long requestedOperations) {
+        return gtlcore$findMaxOperations(target, targetBE, side, baseInputs, requestedOperations);
     }
 
     @Unique


### PR DESCRIPTION
- 通过反射获取 MAE2 样板 P2P 的所有输出端，按各输出端可接受容量的最小值决定智能翻倍的次数，避免单次推送过大批次。
- 将样板供应器的容量校验逻辑暴露给 P2P 输出端复用，使非机器输出端也能走原有的槽位/储罐精确校验。
- 修复某些处理样板在 CPU 执行阶段被误判为合成样板的问题。