### PR TITLE
fix(ae2): 统一 ME 仓室流体单位与数量显示

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/client/gui/widget/AEDualAmountSetWidget.java
+++ b/src/main/java/org/gtlcore/gtlcore/client/gui/widget/AEDualAmountSetWidget.java
@@ -62,7 +62,7 @@ public class AEDualAmountSetWidget extends Widget {
         GuiTextures.BACKGROUND.draw(graphics, mouseX, mouseY, position.x, position.y, WIDGET_WIDTH, WIDGET_HEIGHT);
         DrawerHelper.drawStringSized(
                 graphics,
-                "Amount",
+                isFluidSelected() ? "Amount (mB)" : "Amount",
                 position.x + TEXT_X,
                 position.y + TEXT_Y,
                 0x404040,
@@ -77,6 +77,14 @@ public class AEDualAmountSetWidget extends Widget {
                 position.y + INPUT_Y,
                 INPUT_WIDTH,
                 INPUT_HEIGHT);
+    }
+
+    private boolean isFluidSelected() {
+        if (this.index < 0) {
+            return false;
+        }
+        var config = this.parentWidget.getConfig(this.index).getConfig();
+        return config != null && config.what() instanceof appeng.api.stacks.AEFluidKey;
     }
 
     private String getAmountStr() {

--- a/src/main/java/org/gtlcore/gtlcore/client/gui/widget/AEDualConfigSlotWidget.java
+++ b/src/main/java/org/gtlcore/gtlcore/client/gui/widget/AEDualConfigSlotWidget.java
@@ -1,5 +1,6 @@
 package org.gtlcore.gtlcore.client.gui.widget;
 
+import org.gtlcore.gtlcore.integration.ae2.MEFluidUnits;
 import org.gtlcore.gtlcore.utils.Registries;
 
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
@@ -30,7 +31,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 
 import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEItemKey;
-import appeng.api.stacks.AmountFormat;
 import appeng.api.stacks.GenericStack;
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -50,6 +50,8 @@ import static com.lowdragmc.lowdraglib.gui.widget.PhantomFluidWidget.drainFrom;
  * @author EasterFG on 2025/3/7
  */
 public class AEDualConfigSlotWidget extends Widget implements IGhostItemTarget, IGhostFluidTarget {
+
+    private static final int COMPACT_AMOUNT_MAX_LENGTH = 4;
 
     protected AEDualConfigWidget parentWidget;
     protected int index;
@@ -81,9 +83,11 @@ public class AEDualConfigSlotWidget extends Widget implements IGhostItemTarget, 
                 hoverStringList.add(Component.translatable("gtceu.gui.config_slot"));
                 if (this.parentWidget.isAutoPull()) {
                     hoverStringList.add(Component.translatable("gtceu.gui.config_slot.auto_pull_managed"));
-                } else {
+                } else if (this.parentWidget.isAmountEditingEnabled()) {
                     hoverStringList.add(Component.translatable("gtceu.gui.config_slot.set"));
                     hoverStringList.add(Component.translatable("gtceu.gui.config_slot.scroll"));
+                } else {
+                    hoverStringList.add(Component.translatable("gtceu.gui.config_slot.set_only"));
                 }
                 hoverStringList.add(Component.translatable("gtceu.gui.config_slot.remove"));
                 graphics.renderTooltip(Minecraft.getInstance().font, hoverStringList, Optional.empty(), mouseX, mouseY);
@@ -154,8 +158,8 @@ public class AEDualConfigSlotWidget extends Widget implements IGhostItemTarget, 
                     DrawerHelper.drawFluidForGui(graphics, stack, config.amount(), stackX, stackY, 16, 16);
                 }
             }
-            if (!this.parentWidget.isAutoPull()) {
-                String amount = TextFormattingUtil.formatLongToCompactString(config.amount(), 4);
+            if (this.parentWidget.isAmountEditingEnabled() && !this.parentWidget.isAutoPull()) {
+                String amount = formatAmount(config);
                 drawStringFixedCorner(graphics, amount, stackX + 17, stackY + 17, 16777215, true, 0.5f);
             }
         }
@@ -172,7 +176,7 @@ public class AEDualConfigSlotWidget extends Widget implements IGhostItemTarget, 
                 }
             }
             if (stock.amount() > 0) {
-                drawStringFixedCorner(graphics, stock.what().formatAmount(stock.amount(), AmountFormat.SLOT),
+                drawStringFixedCorner(graphics, formatAmount(stock),
                         stackX + 17, stackY + 18 + 17, 16777215, true, 0.5f);
             }
             if (mouseOverConfig(mouseX, mouseY)) {
@@ -181,6 +185,13 @@ public class AEDualConfigSlotWidget extends Widget implements IGhostItemTarget, 
                 drawSelectionOverlay(graphics, stackX, stackY + 18, 16, 16);
             }
         }
+    }
+
+    private static String formatAmount(GenericStack stack) {
+        if (stack.what() instanceof AEFluidKey) {
+            return MEFluidUnits.formatDisplayAmount(stack.amount());
+        }
+        return TextFormattingUtil.formatLongToCompactString(stack.amount(), COMPACT_AMOUNT_MAX_LENGTH);
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -213,8 +224,10 @@ public class AEDualConfigSlotWidget extends Widget implements IGhostItemTarget, 
                 } else if (!item.isEmpty()) {
                     writeClientAction(ITEM_UPDATE_ID, buf -> buf.writeItem(item));
                 }
-                this.parentWidget.enableAmount(this.getIndex());
-                this.select = true;
+                if (this.parentWidget.isAmountEditingEnabled()) {
+                    this.parentWidget.enableAmount(this.getIndex());
+                    this.select = true;
+                }
             }
         }
         return false;

--- a/src/main/java/org/gtlcore/gtlcore/client/gui/widget/AEDualConfigWidget.java
+++ b/src/main/java/org/gtlcore/gtlcore/client/gui/widget/AEDualConfigWidget.java
@@ -37,6 +37,7 @@ public class AEDualConfigWidget extends WidgetGroup {
     private final ExportOnlyAEItemList aeItem;
     private final ExportOnlyAEFluidList aeFluid;
     private final IntConsumer pageSetter;
+    private final boolean amountEditingEnabled;
 
     public static final int CONFIG_SIZE = 16;
     protected int page;
@@ -46,10 +47,16 @@ public class AEDualConfigWidget extends WidgetGroup {
     private static final int UPDATE_ID = 1001;
 
     public AEDualConfigWidget(int x, int y, ExportOnlyAEItemList aeItem, ExportOnlyAEFluidList aeFluid, IntConsumer pageSetter, int page) {
+        this(x, y, aeItem, aeFluid, pageSetter, page, false);
+    }
+
+    public AEDualConfigWidget(int x, int y, ExportOnlyAEItemList aeItem, ExportOnlyAEFluidList aeFluid,
+                              IntConsumer pageSetter, int page, boolean amountEditingEnabled) {
         super(new Position(x, y), new Size(CONFIG_SIZE / 2 * 18, 18 * 4 + 2 + 19));
         this.aeItem = aeItem;
         this.aeFluid = aeFluid;
         this.pageSetter = pageSetter;
+        this.amountEditingEnabled = amountEditingEnabled;
         this.offset = aeItem.getSize();
         this.page = page;
         this.MAX_PAGE = Math.max(1, offset / CONFIG_SIZE);
@@ -110,7 +117,8 @@ public class AEDualConfigWidget extends WidgetGroup {
     @OnlyIn(Dist.CLIENT)
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (this.amountSetWidget.isVisible() && this.amountSetWidget.getAmountText().mouseClicked(mouseX, mouseY, button)) {
+        if (this.amountEditingEnabled && this.amountSetWidget.isVisible() &&
+                this.amountSetWidget.getAmountText().mouseClicked(mouseX, mouseY, button)) {
             return true;
         }
         for (Widget w : this.widgets) {
@@ -123,6 +131,9 @@ public class AEDualConfigWidget extends WidgetGroup {
     }
 
     public void enableAmount(int index) {
+        if (!this.amountEditingEnabled) {
+            return;
+        }
         this.amountSetWidget.setSlotIndex(index);
         this.amountSetWidget.setVisible(true);
         this.amountSetWidget.getAmountText().setVisible(true);
@@ -132,6 +143,10 @@ public class AEDualConfigWidget extends WidgetGroup {
         this.amountSetWidget.setSlotIndex(-1);
         this.amountSetWidget.setVisible(false);
         this.amountSetWidget.getAmountText().setVisible(false);
+    }
+
+    public boolean isAmountEditingEnabled() {
+        return this.amountEditingEnabled;
     }
 
     @Override

--- a/src/main/java/org/gtlcore/gtlcore/client/gui/widget/MEOutListGridWidget.java
+++ b/src/main/java/org/gtlcore/gtlcore/client/gui/widget/MEOutListGridWidget.java
@@ -1,5 +1,7 @@
 package org.gtlcore.gtlcore.client.gui.widget;
 
+import org.gtlcore.gtlcore.integration.ae2.MEFluidUnits;
+
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.client.TooltipsHandler;
 
@@ -260,7 +262,7 @@ public class MEOutListGridWidget extends DraggableScrollableWidgetGroup {
                 } else if (key instanceof AEFluidKey fluidKey) {
                     FluidStack fs = FluidStack.create(fluidKey.getFluid(), amt, fluidKey.getTag());
                     DrawerHelper.drawFluidForGui(graphics, fs, amt, stackX, stackY, 16, 16);
-                    String amountStr = String.format("x%,d", amt);
+                    String amountStr = MEFluidUnits.formatDisplayAmount(amt);
                     drawText(graphics, amountStr, stackX + 20, stackY + 5, 1, 0xFFFFFFFF);
                 }
             }

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualInputHatchPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualInputHatchPartMachine.java
@@ -141,7 +141,7 @@ public class MEDualInputHatchPartMachine extends MEInputBusPartMachine implement
                 "gtceu.gui.me_network.online" :
                 "gtceu.gui.me_network.offline"));
         group.addWidget(new AEDualConfigWidget(
-                3, 10, this.aeItemHandler, this.aeFluidHandler, this::setPage, this.page));
+                3, 10, this.aeItemHandler, this.aeFluidHandler, this::setPage, this.page, true));
         return group;
     }
 

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/MEFluidUnits.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/MEFluidUnits.java
@@ -1,0 +1,20 @@
+package org.gtlcore.gtlcore.integration.ae2;
+
+import org.gtlcore.gtlcore.utils.NumberUtils;
+
+import net.minecraftforge.fluids.FluidType;
+
+public final class MEFluidUnits {
+
+    private static final String MILLIBUCKET_SUFFIX = "mB";
+    private static final String BUCKET_SUFFIX = "B";
+
+    private MEFluidUnits() {}
+
+    public static String formatDisplayAmount(long amountMb) {
+        if (amountMb < FluidType.BUCKET_VOLUME) {
+            return NumberUtils.formatLong(amountMb) + MILLIBUCKET_SUFFIX;
+        }
+        return NumberUtils.formatDouble((double) amountMb / FluidType.BUCKET_VOLUME) + BUCKET_SUFFIX;
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/integration/jade/MEStockingItemJadeHelper.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jade/MEStockingItemJadeHelper.java
@@ -52,13 +52,14 @@ public final class MEStockingItemJadeHelper {
     }
 
     private static @Nullable ExportOnlyAEItemList getStockingItemHandler(MetaMachine machine) {
-        ExportOnlyAEItemList itemHandler = null;
         if (machine instanceof MEInputBusPartMachine) {
-            itemHandler = ((MEInputBusPartMachineAccessor) machine).gtlcore$getAeItemHandler();
-        } else if (machine instanceof MEDualHatchStockPartMachine) {
-            itemHandler = ((MEDualHatchStockPartMachineAccessor) machine).gtlcore$getAeItemHandler();
+            return ((MEInputBusPartMachineAccessor) machine).gtlcore$getAeItemHandler();
         }
 
+        ExportOnlyAEItemList itemHandler = null;
+        if (machine instanceof MEDualHatchStockPartMachine) {
+            itemHandler = ((MEDualHatchStockPartMachineAccessor) machine).gtlcore$getAeItemHandler();
+        }
         if (itemHandler instanceof IOptimizedMEList optimized && optimized.isStocking()) {
             return itemHandler;
         }

--- a/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/MEMAIOProvider.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/MEMAIOProvider.java
@@ -1,7 +1,7 @@
 package org.gtlcore.gtlcore.integration.jade.provider;
 
 import org.gtlcore.gtlcore.common.machine.multiblock.part.ae.MEMolecularAssemblerIOPartMachine;
-import org.gtlcore.gtlcore.utils.NumberUtils;
+import org.gtlcore.gtlcore.integration.ae2.MEFluidUnits;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
@@ -72,7 +72,7 @@ public class MEMAIOProvider implements IBlockComponentProvider, IServerDataProvi
                     var fluid = fluidKey.toStack(Ints.saturatedCast(count));
                     iTooltip.add(GTElementHelper.smallFluid(JadeFluidObject.of(fluid.getFluid(), count)));
                     Component text = Component.literal(" ")
-                            .append(count < 1000L ? count + "mB" : NumberUtils.formatLong(count / 1000) + "B")
+                            .append(MEFluidUnits.formatDisplayAmount(count))
                             .append(" ")
                             .append(wrapInSquareBrackets(fluid.getDisplayName()).withStyle(ChatFormatting.WHITE))
                             .withStyle(ChatFormatting.WHITE);

--- a/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/MEPatternBufferProvider.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/MEPatternBufferProvider.java
@@ -1,7 +1,7 @@
 package org.gtlcore.gtlcore.integration.jade.provider;
 
 import org.gtlcore.gtlcore.common.machine.multiblock.part.ae.MEPatternBufferPartMachineBase;
-import org.gtlcore.gtlcore.utils.NumberUtils;
+import org.gtlcore.gtlcore.integration.ae2.MEFluidUnits;
 import org.gtlcore.gtlcore.utils.Registries;
 
 import com.gregtechceu.gtceu.GTCEu;
@@ -82,7 +82,7 @@ public class MEPatternBufferProvider implements IBlockComponentProvider, IServer
             if (fluid != null && amount > 0) {
                 iTooltip.add(GTElementHelper.smallFluid(JadeFluidObject.of(fluid)));
                 Component text = Component.literal(" ")
-                        .append(amount < 1000L ? amount + "mB" : NumberUtils.formatLong(amount / 1000) + "B")
+                        .append(MEFluidUnits.formatDisplayAmount(amount))
                         .withStyle(ChatFormatting.DARK_PURPLE)
                         .append(Component.literal(" ").withStyle(ChatFormatting.WHITE))
                         .append(fluid.getFluidType().getDescription().copy().withStyle(ChatFormatting.DARK_AQUA));
@@ -113,7 +113,7 @@ public class MEPatternBufferProvider implements IBlockComponentProvider, IServer
                     var fluid = fluidKey.toStack(Ints.saturatedCast(count));
                     iTooltip.add(GTElementHelper.smallFluid(JadeFluidObject.of(fluid.getFluid(), count)));
                     Component text = Component.literal(" ")
-                            .append(count < 1000L ? count + "mB" : NumberUtils.formatLong(count / 1000) + "B")
+                            .append(MEFluidUnits.formatDisplayAmount(count))
                             .append(" ")
                             .append(wrapInSquareBrackets(fluid.getDisplayName()).withStyle(ChatFormatting.WHITE))
                             .withStyle(ChatFormatting.WHITE);

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/gui/AEFluidConfigSlotWidgetMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/gui/AEFluidConfigSlotWidgetMixin.java
@@ -1,6 +1,6 @@
 package org.gtlcore.gtlcore.mixin.gtm.gui;
 
-import org.gtlcore.gtlcore.utils.NumberUtils;
+import org.gtlcore.gtlcore.integration.ae2.MEFluidUnits;
 
 import com.gregtechceu.gtceu.integration.ae2.gui.widget.slot.AEFluidConfigSlotWidget;
 
@@ -21,11 +21,7 @@ public abstract class AEFluidConfigSlotWidgetMixin {
                index = 1,
                remap = false)
     public String configFormat(String str, @Local(ordinal = 0) GenericStack stack) {
-        long amount = stack.amount();
-        if (amount < 1000) {
-            return amount + "mB";
-        }
-        return NumberUtils.formatLong(amount / 1000) + "B";
+        return MEFluidUnits.formatDisplayAmount(stack.amount());
     }
 
     @ModifyArg(method = "drawInBackground",
@@ -33,10 +29,6 @@ public abstract class AEFluidConfigSlotWidgetMixin {
                index = 1,
                remap = false)
     public String stockFormat(String str, @Local(ordinal = 1) GenericStack stack) {
-        long amount = stack.amount();
-        if (amount < 1000) {
-            return amount + "mB";
-        }
-        return NumberUtils.formatLong(amount / 1000) + "B";
+        return MEFluidUnits.formatDisplayAmount(stack.amount());
     }
 }


### PR DESCRIPTION
## 概要

- 统一普通与库存 ME 仓室的流体数量显示：内部以 mB 运算，低于 1000 显示 mB，达到 1000 后显示 B
- 为双输入总成保留数量编辑，为库存类双仓禁用无效的数量编辑入口
- 统一双仓槽、ME 输出列表、标准 AE 流体槽和 Jade 中的数量格式，并补充非库存 ME 输入总成的 Jade 物品展示

## 验证

- `./gradlew.bat spotlessApply build --no-daemon`