### PR TITLE
feat(gtm): 添加多方块批处理并优化结构加载性能

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/api/gui/GuiTextures.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/gui/GuiTextures.java
@@ -1,9 +1,19 @@
 package org.gtlcore.gtlcore.api.gui;
 
+import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
+
+import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
+import com.lowdragmc.lowdraglib.gui.texture.ItemStackTexture;
 import com.lowdragmc.lowdraglib.gui.texture.ResourceTexture;
+
+import static com.gregtechceu.gtceu.api.data.tag.TagPrefix.dust;
+import static com.gregtechceu.gtceu.api.data.tag.TagPrefix.dustSmall;
+import static com.gregtechceu.gtceu.common.data.GTMaterials.Gold;
 
 public class GuiTextures {
 
     public static final ResourceTexture BUTTON_VISIBLE = new ResourceTexture("gtlcore:textures/guis/button_visible.png");
     public static final ResourceTexture BUTTON_DISABLE_BYPRODUCT = new ResourceTexture("gtlcore:textures/guis/button_disable_byproduct.png");
+    public static final IGuiTexture BATCH_PROCESSING_DISABLED = new ItemStackTexture(ChemicalHelper.get(dustSmall, Gold));
+    public static final IGuiTexture BATCH_PROCESSING_ENABLED = new ItemStackTexture(ChemicalHelper.get(dust, Gold));
 }

--- a/src/main/java/org/gtlcore/gtlcore/api/machine/trait/IBatchMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/machine/trait/IBatchMachine.java
@@ -1,0 +1,43 @@
+package org.gtlcore.gtlcore.api.machine.trait;
+
+import org.gtlcore.gtlcore.api.gui.GuiTextures;
+
+import com.gregtechceu.gtceu.api.gui.fancy.ConfiguratorPanel;
+import com.gregtechceu.gtceu.api.gui.fancy.IFancyConfiguratorButton;
+import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
+
+import net.minecraft.network.chat.Component;
+
+import java.util.List;
+
+public interface IBatchMachine {
+
+    boolean isBatchEnabled();
+
+    void setBatchEnabled(boolean enabled);
+
+    default boolean supportsBatchProcessing() {
+        return true;
+    }
+
+    default boolean canConfigureBatchProcessing() {
+        return supportsBatchProcessing();
+    }
+
+    static void attachBatchConfigurator(ConfiguratorPanel configuratorPanel,
+                                        WorkableElectricMultiblockMachine machine) {
+        if (!((Object) machine instanceof IBatchMachine batchMachine) ||
+                !batchMachine.canConfigureBatchProcessing())
+            return;
+
+        configuratorPanel.attachConfigurators(new IFancyConfiguratorButton.Toggle(
+                GuiTextures.BATCH_PROCESSING_DISABLED,
+                GuiTextures.BATCH_PROCESSING_ENABLED,
+                () -> batchMachine.supportsBatchProcessing() && batchMachine.isBatchEnabled(),
+                (clickData, pressed) -> batchMachine.setBatchEnabled(pressed))
+                .setTooltipsSupplier(pressed -> List.of(Component.translatable(
+                        !batchMachine.supportsBatchProcessing() ? "gui.gtlcore.batch_processing.unsupported_mode" :
+                                pressed ? "gui.gtlcore.batch_processing.enabled" :
+                                        "gui.gtlcore.batch_processing.disabled"))));
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/api/pattern/AdvancedBlockPattern.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/pattern/AdvancedBlockPattern.java
@@ -71,6 +71,9 @@ import java.util.function.*;
 
 public class AdvancedBlockPattern extends BlockPattern {
 
+    public static final String MATCHED_REPETITIONS_CONTEXT = "gtlcore:matched_repetitions";
+    public static final String MATCHED_MIN_Z_CONTEXT = "gtlcore:matched_min_z";
+
     static Direction[] FACINGS = { Direction.SOUTH, Direction.NORTH, Direction.WEST, Direction.EAST, Direction.UP,
             Direction.DOWN };
     static Direction[] FACINGS_H = { Direction.SOUTH, Direction.NORTH, Direction.WEST, Direction.EAST };
@@ -166,14 +169,7 @@ public class AdvancedBlockPattern extends BlockPattern {
         blocks.put(centerPos, controller);
         if (controller.isFormed() && autoBuildSetting.isReplaceMode()) controller.onStructureInvalid();
 
-        int[] repeat = new int[this.fingerLength];
-        for (int h = 0; h < this.fingerLength; h++) {
-            var minH = aisleRepetitions[h][0];
-            var maxH = aisleRepetitions[h][1];
-            if (minH != maxH) {
-                repeat[h] = Math.max(minH, Math.min(maxH, autoBuildSetting.getRepeatCount()));
-            } else repeat[h] = minH;
-        }
+        int[] repeat = getConfiguredRepetitions(autoBuildSetting.getRepeatCount());
 
         for (int c = 0, z = minZ, r; c < this.fingerLength; c++) {
             for (r = 0; r < repeat[c]; r++) {
@@ -384,28 +380,31 @@ public class AdvancedBlockPattern extends BlockPattern {
         Direction facing = controller.self().getFrontFacing();
         Direction upwardsFacing = controller.self().getUpwardsFacing();
 
-        int repeatCountSetting = autoBuildSetting.getRepeatCount();
-        boolean isFlipped = autoBuildSetting.isFlipped();
         boolean aeMode = autoBuildSetting.isAeMode();
         GlobalPos boundAE = autoBuildSetting.getBoundAE();
         IGrid grid = aeMode ? findBestGrid(level, player, boundAE) : null;
         var aeInventory = grid != null ? grid.getStorageService().getInventory() : null;
         IActionSource source = IActionSource.ofPlayer(player);
 
-        // 获取多方块状态用于判定方块是否有效
         MultiblockState worldState = controller.getMultiblockState();
-
-        // 计算重复次数
-        int[] repeat = new int[this.fingerLength];
-        for (int h = 0; h < this.fingerLength; h++) {
-            var minH = this.aisleRepetitions[h][0];
-            var maxH = this.aisleRepetitions[h][1];
-            if (minH != maxH) {
-                repeat[h] = Math.max(minH, Math.min(maxH, repeatCountSetting));
-            } else repeat[h] = minH;
+        DismantleLayout layout = null;
+        if (controller.getPattern().checkPatternAt(worldState, true)) {
+            var matchContext = worldState.getMatchContext();
+            int[] repetitions = matchContext.get(MATCHED_REPETITIONS_CONTEXT);
+            if (repetitions != null && repetitions.length == this.fingerLength &&
+                    matchContext.containsKey(MATCHED_MIN_Z_CONTEXT)) {
+                layout = new DismantleLayout(matchContext.getInt(MATCHED_MIN_Z_CONTEXT), repetitions,
+                        worldState.isNeededFlip(), Integer.MAX_VALUE);
+            }
+        }
+        if (layout == null) {
+            layout = findBestPartialDismantleLayout(level, centerPos, facing, upwardsFacing,
+                    controller.self().allowFlip());
         }
 
-        int minZ = -this.centerOffset[4];
+        int[] repeat = layout.repetitions();
+        int minZ = layout.minZ();
+        boolean isFlipped = layout.isFlipped();
 
         // 遍历模式中的每一个位置
         for (int c = 0, z = minZ; c < this.fingerLength; c++) {
@@ -479,6 +478,95 @@ public class AdvancedBlockPattern extends BlockPattern {
         if (controller instanceof WorkableMultiblockMachine machine) {
             machine.onPartUnload();
         }
+    }
+
+    private DismantleLayout findBestPartialDismantleLayout(Level level, BlockPos centerPos, Direction facing,
+                                                           Direction upwardsFacing, boolean allowsFlip) {
+        DismantleLayout normal = findPartialDismantleLayout(level, centerPos, facing, upwardsFacing, false);
+        if (!allowsFlip) return normal;
+        DismantleLayout flipped = findPartialDismantleLayout(level, centerPos, facing, upwardsFacing, true);
+        return flipped.score() > normal.score() ? flipped : normal;
+    }
+
+    private DismantleLayout findPartialDismantleLayout(Level level, BlockPos centerPos, Direction facing,
+                                                       Direction upwardsFacing, boolean isFlipped) {
+        int controllerAisle = this.centerOffset[2];
+        int[] repetitions = new int[this.fingerLength];
+        MultiblockState probeState = new MultiblockState(level, centerPos);
+        int score = 0;
+
+        int z = 0;
+        for (int aisle = controllerAisle; aisle < this.fingerLength; aisle++) {
+            int count = findPartialRepetitions(level, centerPos, facing, upwardsFacing, isFlipped, probeState,
+                    aisle, z, 1);
+            repetitions[aisle] = count;
+            for (int repeat = 0; repeat < count; repeat++) {
+                score += scoreSlice(level, centerPos, facing, upwardsFacing, isFlipped, probeState, aisle,
+                        z + repeat);
+            }
+            z += count;
+        }
+
+        z = -1;
+        for (int aisle = controllerAisle - 1; aisle >= 0; aisle--) {
+            int count = findPartialRepetitions(level, centerPos, facing, upwardsFacing, isFlipped, probeState,
+                    aisle, z, -1);
+            repetitions[aisle] = count;
+            for (int repeat = 0; repeat < count; repeat++) {
+                score += scoreSlice(level, centerPos, facing, upwardsFacing, isFlipped, probeState, aisle,
+                        z - repeat);
+            }
+            z -= count;
+        }
+        return new DismantleLayout(z + 1, repetitions, isFlipped, score);
+    }
+
+    private int findPartialRepetitions(Level level, BlockPos centerPos, Direction facing, Direction upwardsFacing,
+                                       boolean isFlipped, MultiblockState probeState, int aisle, int startZ,
+                                       int step) {
+        int min = this.aisleRepetitions[aisle][0];
+        int max = this.aisleRepetitions[aisle][1];
+        if (min == max) return min;
+
+        int adjacentAisle = aisle + step;
+        int count = 0;
+        while (count < max) {
+            int z = startZ + count * step;
+            int currentScore = scoreSlice(level, centerPos, facing, upwardsFacing, isFlipped, probeState, aisle, z);
+            int adjacentScore = adjacentAisle >= 0 && adjacentAisle < this.fingerLength ?
+                    scoreSlice(level, centerPos, facing, upwardsFacing, isFlipped, probeState, adjacentAisle, z) : 0;
+            if (adjacentScore > currentScore || currentScore == 0 && count >= min) break;
+            count++;
+        }
+        return count;
+    }
+
+    private int scoreSlice(Level level, BlockPos centerPos, Direction facing, Direction upwardsFacing,
+                           boolean isFlipped, MultiblockState probeState, int aisle, int z) {
+        int score = 0;
+        for (int b = 0, y = -this.centerOffset[1]; b < this.thumbLength; b++, y++) {
+            for (int a = 0, x = -this.centerOffset[0]; a < this.palmLength; a++, x++) {
+                TraceabilityPredicate predicate = this.blockMatches[aisle][b][a];
+                if (predicate.isAny()) continue;
+                BlockPos pos = setActualRelativeOffset(x, y, z, facing, upwardsFacing, isFlipped)
+                        .offset(centerPos.getX(), centerPos.getY(), centerPos.getZ());
+                BlockState blockState = level.getBlockState(pos);
+                if (!blockState.isAir() && isBlockValid(blockState, pos, predicate, probeState)) score++;
+            }
+        }
+        return score;
+    }
+
+    private record DismantleLayout(int minZ, int[] repetitions, boolean isFlipped, int score) {}
+
+    private int[] getConfiguredRepetitions(int repeatCount) {
+        int[] repetitions = new int[this.fingerLength];
+        for (int aisle = 0; aisle < this.fingerLength; aisle++) {
+            int min = this.aisleRepetitions[aisle][0];
+            int max = this.aisleRepetitions[aisle][1];
+            repetitions[aisle] = min == max ? min : Math.max(min, Math.min(max, repeatCount));
+        }
+        return repetitions;
     }
 
     private boolean isBlockValid(BlockState current, BlockPos pos, TraceabilityPredicate predicate, MultiblockState tempState) {

--- a/src/main/java/org/gtlcore/gtlcore/api/recipe/BatchProcessing.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/recipe/BatchProcessing.java
@@ -1,0 +1,209 @@
+package org.gtlcore.gtlcore.api.recipe;
+
+import org.gtlcore.gtlcore.api.machine.trait.IBatchMachine;
+import org.gtlcore.gtlcore.api.recipe.ingredient.LongIngredient;
+import org.gtlcore.gtlcore.common.machine.trait.MultipleRecipesLogic;
+import org.gtlcore.gtlcore.config.ConfigHolder;
+
+import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
+import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
+import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.content.Content;
+import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
+import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
+
+import net.minecraft.world.item.crafting.Ingredient;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static org.gtlcore.gtlcore.api.recipe.IAdvancedContentModifier.preciseMultiplier;
+
+public final class BatchProcessing {
+
+    private static final ClassValue<MultipleRecipeModeAccess> MULTIPLE_RECIPE_MODE_ACCESS = new ClassValue<>() {
+
+        @Override
+        protected MultipleRecipeModeAccess computeValue(Class<?> type) {
+            return new MultipleRecipeModeAccess(
+                    findMethod(type, List.of("isMultipleMode", "getMultipleMode")),
+                    findMethod(type, List.of("setMultipleMode", "setIsMultipleMode"), boolean.class),
+                    findMethod(type, List.of("useModes")));
+        }
+    };
+
+    private BatchProcessing() {}
+
+    public static boolean isEnabled(MetaMachine machine) {
+        return machine instanceof IBatchMachine batchMachine && batchMachine.supportsBatchProcessing() &&
+                batchMachine.isBatchEnabled();
+    }
+
+    public static boolean isCrossRecipeParallel(IRecipeLogicMachine machine) {
+        if (!(machine.getRecipeLogic() instanceof MultipleRecipesLogic)) return false;
+
+        var modeGetter = MULTIPLE_RECIPE_MODE_ACCESS.get(machine.getClass()).modeGetter();
+        return modeGetter.isEmpty() || invokeBoolean(modeGetter.get(), machine, true);
+    }
+
+    public static boolean canConfigureBatchProcessing(IRecipeLogicMachine machine) {
+        if (!(machine.getRecipeLogic() instanceof MultipleRecipesLogic)) return true;
+
+        var access = MULTIPLE_RECIPE_MODE_ACCESS.get(machine.getClass());
+        if (access.modeGetter().isEmpty() || access.modeSetter().isEmpty()) return false;
+        return access.useModesGetter().isEmpty() || invokeBoolean(access.useModesGetter().get(), machine, true);
+    }
+
+    public static GTRecipe apply(MetaMachine machine, GTRecipe recipe) {
+        if (!isEnabled(machine) || IGTRecipe.of(recipe).isBatchProcessed() ||
+                !(machine instanceof IRecipeLogicMachine recipeMachine)) {
+            return recipe;
+        }
+
+        int batchSize = getBatchSize(recipeMachine, recipe);
+        if (batchSize == 0) return null;
+        GTRecipe result = batchSize > 1 ? scaleRecipe(recipe, batchSize) : recipe;
+        result = IParallelLogic.getRecipeOutputChance(recipeMachine, result);
+        IGTRecipe.of(result).setBatchSize(batchSize);
+        IGTRecipe.of(result).setBatchProcessed(true);
+        return result;
+    }
+
+    public static boolean applyInPlace(MetaMachine machine, GTRecipe recipe) {
+        GTRecipe result = apply(machine, recipe);
+        if (result == null) return false;
+        if (result == recipe) return true;
+
+        var inputs = new HashMap<>(result.inputs);
+        var outputs = new HashMap<>(result.outputs);
+        var tickInputs = new HashMap<>(result.tickInputs);
+        var tickOutputs = new HashMap<>(result.tickOutputs);
+        recipe.inputs.clear();
+        recipe.inputs.putAll(inputs);
+        recipe.outputs.clear();
+        recipe.outputs.putAll(outputs);
+        recipe.tickInputs.clear();
+        recipe.tickInputs.putAll(tickInputs);
+        recipe.tickOutputs.clear();
+        recipe.tickOutputs.putAll(tickOutputs);
+        recipe.duration = result.duration;
+        recipe.ocTier = result.ocTier;
+        RecipeExtensionCopier.copy(result, recipe);
+        return true;
+    }
+
+    private static int getBatchSize(IRecipeLogicMachine machine, GTRecipe recipe) {
+        if (recipe.duration <= 0) return 1;
+
+        int timeLimit = Math.max(1, ConfigHolder.INSTANCE.batchProcessingTimeLimitTicks);
+        int maxCycles = timeLimit / recipe.duration;
+        long realParallels = Math.max(1, IGTRecipe.of(recipe).getRealParallels());
+        maxCycles = (int) Math.min(maxCycles, Long.MAX_VALUE / realParallels);
+        maxCycles = limitByLongAmounts(recipe, maxCycles);
+        if (maxCycles <= 0) return 0;
+        if (maxCycles == 1) return 1;
+
+        return getParallelAmountWithoutEU(machine, recipe, maxCycles);
+    }
+
+    private static int limitByLongAmounts(GTRecipe recipe, int limit) {
+        limit = limitByTotalAmount(limit, getTotalItemAmount(recipe.getInputContents(ItemRecipeCapability.CAP)));
+        limit = limitByTotalAmount(limit, getTotalFluidAmount(recipe.getInputContents(FluidRecipeCapability.CAP)));
+        limit = limitByTotalAmount(limit, getTotalItemAmount(recipe.getOutputContents(ItemRecipeCapability.CAP)));
+        return limitByTotalAmount(limit, getTotalFluidAmount(recipe.getOutputContents(FluidRecipeCapability.CAP)));
+    }
+
+    private static int limitByTotalAmount(int limit, long totalAmount) {
+        if (totalAmount < 0) return 0;
+        if (totalAmount == 0) return limit;
+        return (int) Math.min(limit, Long.MAX_VALUE / totalAmount);
+    }
+
+    private static long getTotalItemAmount(List<Content> contents) {
+        long total = 0;
+        for (Content content : contents) {
+            Ingredient ingredient = ItemRecipeCapability.CAP.of(content.content);
+            long amount = ingredient instanceof LongIngredient longIngredient ?
+                    longIngredient.getActualAmount() :
+                    ingredient instanceof SizedIngredient sizedIngredient ? sizedIngredient.getAmount() : 1;
+            if (amount < 0) return -1;
+            if (amount > Long.MAX_VALUE - total) return -1;
+            total += amount;
+        }
+        return total;
+    }
+
+    private static long getTotalFluidAmount(List<Content> contents) {
+        long total = 0;
+        for (Content content : contents) {
+            FluidIngredient ingredient = FluidRecipeCapability.CAP.of(content.content);
+            long amount = ingredient.getAmount();
+            if (amount < 0) return -1;
+            if (amount > Long.MAX_VALUE - total) return -1;
+            total += amount;
+        }
+        return total;
+    }
+
+    private static int getParallelAmountWithoutEU(IRecipeLogicMachine machine, GTRecipe recipe, int limit) {
+        long parallel = IParallelLogic.getParallel(machine, recipe, limit);
+        if (parallel == 0) return 0;
+
+        for (RecipeCapability<?> capability : recipe.inputs.keySet()) {
+            if (capability.doMatchInRecipe() && capability != ItemRecipeCapability.CAP &&
+                    capability != FluidRecipeCapability.CAP) {
+                parallel = Math.min(parallel, capability.getMaxParallelRatio(machine, recipe, (int) parallel));
+            }
+        }
+        for (RecipeCapability<?> capability : recipe.outputs.keySet()) {
+            if (capability.doMatchInRecipe() && capability != ItemRecipeCapability.CAP &&
+                    capability != FluidRecipeCapability.CAP && !machine.canVoidRecipeOutputs(capability)) {
+                parallel = Math.min(parallel, capability.limitParallel(recipe, machine, (int) parallel));
+            }
+        }
+        return (int) parallel;
+    }
+
+    private static GTRecipe scaleRecipe(GTRecipe recipe, int batchSize) {
+        GTRecipe batched = recipe.copy(preciseMultiplier(batchSize), false);
+        RecipeExtensionCopier.copy(recipe, batched);
+
+        batched.tickInputs.clear();
+        batched.tickInputs.putAll(recipe.tickInputs);
+        batched.tickOutputs.clear();
+        batched.tickOutputs.putAll(recipe.tickOutputs);
+        batched.duration = recipe.duration * batchSize;
+        batched.ocTier = recipe.ocTier;
+        IGTRecipe.of(batched).setRealParallels(IGTRecipe.of(recipe).getRealParallels() * batchSize);
+        return batched;
+    }
+
+    private static Optional<Method> findMethod(Class<?> type, List<String> names, Class<?>... parameterTypes) {
+        for (String name : names) {
+            try {
+                return Optional.of(type.getMethod(name, parameterTypes));
+            } catch (NoSuchMethodException ignored) {
+                // Optional compatibility method is not present on this machine type.
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static boolean invokeBoolean(Method method, Object target, boolean fallback) {
+        try {
+            Object result = method.invoke(target);
+            return result instanceof Boolean value ? value : fallback;
+        } catch (IllegalAccessException | InvocationTargetException exception) {
+            return fallback;
+        }
+    }
+
+    private record MultipleRecipeModeAccess(Optional<Method> modeGetter, Optional<Method> modeSetter,
+                                            Optional<Method> useModesGetter) {}
+}

--- a/src/main/java/org/gtlcore/gtlcore/api/recipe/IAdvancedContentModifier.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/recipe/IAdvancedContentModifier.java
@@ -11,4 +11,10 @@ public interface IAdvancedContentModifier {
         ((IAdvancedContentModifier) modifier).setDivision(numerator, denominator);
         return modifier;
     }
+
+    static ContentModifier preciseMultiplier(long multiplier) {
+        var modifier = new ContentModifier(multiplier, 0);
+        ((IAdvancedContentModifier) modifier).setDivision(multiplier, 1);
+        return modifier;
+    }
 }

--- a/src/main/java/org/gtlcore/gtlcore/api/recipe/IGTRecipe.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/recipe/IGTRecipe.java
@@ -15,4 +15,12 @@ public interface IGTRecipe {
     long getRealParallels();
 
     void setRealParallels(long realParallels);
+
+    int getBatchSize();
+
+    void setBatchSize(int batchSize);
+
+    boolean isBatchProcessed();
+
+    void setBatchProcessed(boolean batchProcessed);
 }

--- a/src/main/java/org/gtlcore/gtlcore/api/recipe/IParallelLogic.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/recipe/IParallelLogic.java
@@ -63,6 +63,7 @@ public interface IParallelLogic {
         var copy = new GTRecipe(recipe.recipeType, recipe.id, recipe.inputs, recipeContents, recipe.tickInputs, recipe.tickOutputs,
                 recipe.inputChanceLogics, recipe.outputChanceLogics, recipe.tickInputChanceLogics, recipe.tickOutputChanceLogics,
                 recipe.conditions, recipe.ingredientActions, recipe.data, recipe.duration, recipe.isFuel);
+        RecipeExtensionCopier.copy(recipe, copy);
         ((IGTRecipe) copy).setRealParallels(((IGTRecipe) recipe).getRealParallels());
         copy.ocTier = recipe.ocTier;
         return copy;

--- a/src/main/java/org/gtlcore/gtlcore/api/recipe/RecipeExtensionCopier.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/recipe/RecipeExtensionCopier.java
@@ -1,0 +1,79 @@
+package org.gtlcore.gtlcore.api.recipe;
+
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RecipeExtensionCopier {
+
+    private static final ClassValue<List<Property>> PROPERTIES = new ClassValue<>() {
+
+        @Override
+        protected List<Property> computeValue(Class<?> type) {
+            List<Property> properties = new ArrayList<>();
+            for (Class<?> extensionInterface : type.getInterfaces()) {
+                for (Method getter : extensionInterface.getMethods()) {
+                    String propertyName = getPropertyName(getter);
+                    if (propertyName == null) continue;
+
+                    try {
+                        Method setter = extensionInterface.getMethod("set" + propertyName,
+                                getter.getReturnType());
+                        if (isSetter(setter)) {
+                            properties.add(new Property(getter, setter));
+                        }
+                    } catch (NoSuchMethodException ignored) {
+                        // Read-only interface properties do not carry extension state into recipe copies.
+                    }
+                }
+            }
+            return List.copyOf(properties);
+        }
+    };
+
+    private RecipeExtensionCopier() {}
+
+    public static GTRecipe copy(GTRecipe source, GTRecipe target) {
+        for (Property property : PROPERTIES.get(source.getClass())) {
+            property.copy(source, target);
+        }
+        return target;
+    }
+
+    private static boolean isSetter(Method method) {
+        return Modifier.isPublic(method.getModifiers()) && method.getName().startsWith("set") &&
+                method.getName().length() > 3 && method.getParameterCount() == 1 &&
+                method.getReturnType() == void.class;
+    }
+
+    private static String getPropertyName(Method method) {
+        if (!Modifier.isPublic(method.getModifiers()) || method.getParameterCount() != 0 ||
+                method.getReturnType() == void.class) {
+            return null;
+        }
+        if (method.getName().startsWith("get") && method.getName().length() > 3) {
+            return method.getName().substring(3);
+        }
+        if (method.getName().startsWith("is") && method.getName().length() > 2 &&
+                (method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class)) {
+            return method.getName().substring(2);
+        }
+        return null;
+    }
+
+    private record Property(Method getter, Method setter) {
+
+        private void copy(GTRecipe source, GTRecipe target) {
+            try {
+                setter.invoke(target, getter.invoke(source));
+            } catch (IllegalAccessException | InvocationTargetException exception) {
+                throw new IllegalStateException("Failed to copy extended recipe property " + getter.getName(),
+                        exception);
+            }
+        }
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/electric/TransfiniteComputationArrayMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/electric/TransfiniteComputationArrayMachine.java
@@ -15,6 +15,7 @@ import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IDisplayUIMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
+import com.gregtechceu.gtceu.api.pattern.MultiblockWorldSavedData;
 
 import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
@@ -35,6 +36,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
 
 import appeng.api.config.Actionable;
@@ -59,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 public class TransfiniteComputationArrayMachine extends MultiblockControllerMachine
@@ -75,6 +78,7 @@ public class TransfiniteComputationArrayMachine extends MultiblockControllerMach
     private static final String NBT_CPU_ID = "Id";
     private static final String NBT_CPU_BYTES = "Bytes";
     private static final String NBT_CPU_STATE = "State";
+    private static final long ASYNC_PATTERN_CHECK_INTERVAL = 4L;
     private static final int UI_WIDTH = 198;
     private static final int UI_HEIGHT = 208;
     private static final int MAIN_PAGE_WIDTH = 190;
@@ -111,9 +115,37 @@ public class TransfiniteComputationArrayMachine extends MultiblockControllerMach
     @Nullable
     private MECraftingCPUInterfacePartMachine networkInterface;
     private TransfiniteCraftingCPU capacityCpu;
+    private final AtomicBoolean patternCheckQueued = new AtomicBoolean();
 
     public TransfiniteComputationArrayMachine(IMachineBlockEntity holder) {
         super(holder);
+    }
+
+    @Override
+    public void asyncCheckPattern(long periodID) {
+        if ((isFormed() && !getMultiblockState().hasError()) ||
+                Math.floorMod(getHolder().getOffset() + periodID, ASYNC_PATTERN_CHECK_INTERVAL) != 0 ||
+                !this.patternCheckQueued.compareAndSet(false, true)) {
+            return;
+        }
+        if (!(getLevel() instanceof ServerLevel serverLevel)) {
+            this.patternCheckQueued.set(false);
+            return;
+        }
+        serverLevel.getServer().execute(() -> {
+            try {
+                if (isInValid() || getLevel() != serverLevel) return;
+                if (checkPatternWithLock()) {
+                    setFlipped(getMultiblockState().isNeededFlip());
+                    onStructureFormed();
+                    var savedData = MultiblockWorldSavedData.getOrCreate(serverLevel);
+                    savedData.addMapping(getMultiblockState());
+                    savedData.removeAsyncLogic(this);
+                }
+            } finally {
+                this.patternCheckQueued.set(false);
+            }
+        });
     }
 
     public void setParallelism(long parallelism) {

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualHatchStockPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualHatchStockPartMachine.java
@@ -414,6 +414,8 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
 
         protected IntArrayList configIndexList = new IntArrayList();
 
+        private long lastSnapshotTick = Long.MIN_VALUE;
+
         public ExportOnlyAEStockingItemList(MetaMachine holder, int slots) {
             super(holder, slots, ExportOnlyAEStockingItemSlot::new);
             for (ExportOnlyAEItemSlot exportOnlyAEItemSlot : inventory) {
@@ -432,6 +434,7 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
 
         @Override
         public void onConfigChanged() {
+            lastSnapshotTick = Long.MIN_VALUE;
             configList.clear();
             configIndexList.clear();
             for (int i = 0, inventoryLength = inventory.length; i < inventoryLength; i++) {
@@ -512,15 +515,20 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
 
         @Override
         public @Nullable Object2LongMap<ItemStack> getMEItemMap() {
-            if (ENABLE_ULTIMATE_ME_STOCKING || getChanged()) {
+            long currentTick = getOffsetTimer();
+            if (getChanged() || ENABLE_ULTIMATE_ME_STOCKING && lastSnapshotTick != currentTick) {
                 setChanged(false);
+                lastSnapshotTick = currentTick;
                 final var itemMap = getItemMap();
                 itemMap.clear();
-                final MEStorage aeNetwork = Objects.requireNonNull(getMainNode().getGrid()).getStorageService().getInventory();
-                for (var key : configList) {
-                    long extracted = aeNetwork.extract(key, Long.MAX_VALUE, Actionable.SIMULATE, getActionSource());
-                    if (extracted > 0) {
-                        itemMap.addTo(key.toStack(), extracted);
+                IGrid grid = getMainNode().getGrid();
+                if (grid != null) {
+                    final MEStorage aeNetwork = grid.getStorageService().getInventory();
+                    for (var key : configList) {
+                        long extracted = aeNetwork.extract(key, Long.MAX_VALUE, Actionable.SIMULATE, getActionSource());
+                        if (extracted > 0) {
+                            itemMap.addTo(key.toStack(), extracted);
+                        }
                     }
                 }
             }
@@ -582,6 +590,8 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
 
         protected IntArrayList configIndexList = new IntArrayList();
 
+        private long lastSnapshotTick = Long.MIN_VALUE;
+
         public ExportOnlyAEStockingFluidList(MetaMachine holder, int slots) {
             super(holder, slots, ExportOnlyAEStockingFluidSlot::new);
             for (ExportOnlyAEFluidSlot exportOnlyAEFluidSlot : inventory) {
@@ -600,6 +610,7 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
 
         @Override
         public void onConfigChanged() {
+            lastSnapshotTick = Long.MIN_VALUE;
             configList.clear();
             configIndexList.clear();
             for (int i = 0, inventoryLength = inventory.length; i < inventoryLength; i++) {
@@ -677,8 +688,10 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
 
         @Override
         public List<FluidStack> getMEFluidList() {
-            if (ENABLE_ULTIMATE_ME_STOCKING || getChanged()) {
+            long currentTick = getOffsetTimer();
+            if (getChanged() || ENABLE_ULTIMATE_ME_STOCKING && lastSnapshotTick != currentTick) {
                 setChanged(false);
+                lastSnapshotTick = currentTick;
                 final var fluidList = getFluidList();
                 fluidList.clear();
                 IGrid grid = getMainNode().getGrid();

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/TagFilterMEStockBusPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/TagFilterMEStockBusPartMachine.java
@@ -265,6 +265,8 @@ public class TagFilterMEStockBusPartMachine extends MEInputBusPartMachine implem
 
         protected IntArrayList configIndexList = new IntArrayList();
 
+        private long lastSnapshotTick = Long.MIN_VALUE;
+
         public ExportOnlyAEStockingItemList(MetaMachine holder, int slots) {
             super(holder, slots, ExportOnlyAEStockingItemSlot::new);
             for (ExportOnlyAEItemSlot exportOnlyAEItemSlot : inventory) {
@@ -283,6 +285,7 @@ public class TagFilterMEStockBusPartMachine extends MEInputBusPartMachine implem
 
         @Override
         public void onConfigChanged() {
+            lastSnapshotTick = Long.MIN_VALUE;
             configList.clear();
             configIndexList.clear();
             for (int i = 0, inventoryLength = inventory.length; i < inventoryLength; i++) {
@@ -365,8 +368,10 @@ public class TagFilterMEStockBusPartMachine extends MEInputBusPartMachine implem
 
         @Override
         public @Nullable Object2LongMap<ItemStack> getMEItemMap() {
-            if (ENABLE_ULTIMATE_ME_STOCKING || getChanged()) {
+            long currentTick = getOffsetTimer();
+            if (getChanged() || ENABLE_ULTIMATE_ME_STOCKING && lastSnapshotTick != currentTick) {
                 setChanged(false);
+                lastSnapshotTick = currentTick;
                 final var itemMap = getItemMap();
                 itemMap.clear();
                 final MEStorage aeNetwork = Objects.requireNonNull(getMainNode().getGrid()).getStorageService().getInventory();

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/TagFilterMEStockHatchPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/TagFilterMEStockHatchPartMachine.java
@@ -261,6 +261,8 @@ public class TagFilterMEStockHatchPartMachine extends MEInputHatchPartMachine im
 
         protected IntArrayList configIndexList = new IntArrayList();
 
+        private long lastSnapshotTick = Long.MIN_VALUE;
+
         public ExportOnlyAEStockingFluidList(MetaMachine holder, int slots) {
             super(holder, slots, ExportOnlyAEStockingFluidSlot::new);
             for (ExportOnlyAEFluidSlot exportOnlyAEFluidSlot : inventory) {
@@ -279,6 +281,7 @@ public class TagFilterMEStockHatchPartMachine extends MEInputHatchPartMachine im
 
         @Override
         public void onConfigChanged() {
+            lastSnapshotTick = Long.MIN_VALUE;
             configList.clear();
             configIndexList.clear();
             for (int i = 0, inventoryLength = inventory.length; i < inventoryLength; i++) {
@@ -357,8 +360,10 @@ public class TagFilterMEStockHatchPartMachine extends MEInputHatchPartMachine im
 
         @Override
         public List<FluidStack> getMEFluidList() {
-            if (ENABLE_ULTIMATE_ME_STOCKING || getChanged()) {
+            long currentTick = getOffsetTimer();
+            if (getChanged() || ENABLE_ULTIMATE_ME_STOCKING && lastSnapshotTick != currentTick) {
                 setChanged(false);
+                lastSnapshotTick = currentTick;
                 final var fluidList = getFluidList();
                 fluidList.clear();
                 final MEStorage aeNetwork = Objects.requireNonNull(getMainNode().getGrid()).getStorageService().getInventory();

--- a/src/main/java/org/gtlcore/gtlcore/config/ConfigHolder.java
+++ b/src/main/java/org/gtlcore/gtlcore/config/ConfigHolder.java
@@ -109,6 +109,11 @@ public class ConfigHolder {
     public boolean sendUpdateMessages = true;
 
     @Configurable
+    @Configurable.Comment("Maximum processing time for one recipe batch, in ticks")
+    @Configurable.Range(min = 1)
+    public int batchProcessingTimeLimitTicks = 100;
+
+    @Configurable
     public String[] mobList1 = new String[] { "chicken", "rabbit", "sheep", "cow", "horse", "pig", "donkey", "skeleton_horse", "iron_golem", "wolf", "goat", "parrot", "camel", "cat", "fox", "llama", "panda", "polar_bear" };
     @Configurable
     public String[] mobList2 = new String[] { "ghast", "zombie", "pillager", "zombie_villager", "skeleton", "drowned", "witch", "spider", "creeper", "husk", "wither_skeleton", "blaze", "zombified_piglin", "slime", "vindicator", "enderman" };

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/throughput/ThroughputMonitorTerminalMenu.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/throughput/ThroughputMonitorTerminalMenu.java
@@ -71,6 +71,7 @@ public class ThroughputMonitorTerminalMenu extends AEBaseMenu {
     private ThroughputMonitorUpdateInterval updateInterval = ThroughputMonitorUpdateInterval.SECOND;
     private int ticksUntilSync;
     private boolean initialSyncPending;
+    private boolean terminalCollectorOpen;
 
     public static ThroughputMonitorTerminalMenu createWiredClientMenu(int containerId, Inventory inventory,
                                                                       FriendlyByteBuf data) {
@@ -109,6 +110,10 @@ public class ThroughputMonitorTerminalMenu extends AEBaseMenu {
         this.menuPlayer = inventory.player;
         this.entries = List.of();
         this.initialSyncPending = terminal != null || wirelessCollector != null;
+        if (terminal != null) {
+            terminal.openMonitor();
+            terminalCollectorOpen = true;
+        }
         if (locator != null) {
             setLocator(locator);
             setReturnedFromSubScreen(returningFromSubmenu);
@@ -291,6 +296,10 @@ public class ThroughputMonitorTerminalMenu extends AEBaseMenu {
 
     @Override
     public void removed(@NotNull Player player) {
+        if (terminalCollectorOpen) {
+            terminal.closeMonitor();
+            terminalCollectorOpen = false;
+        }
         if (wirelessCollector != null) {
             wirelessCollector.close();
         }

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/throughput/ThroughputMonitorTerminalPart.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/throughput/ThroughputMonitorTerminalPart.java
@@ -42,6 +42,7 @@ public class ThroughputMonitorTerminalPart extends AbstractDisplayPart
 
     private final ThroughputMonitorCollector collector = new ThroughputMonitorCollector();
     private final AppEngInternalInventory viewCells = new AppEngInternalInventory(this, VIEW_CELL_SLOT_COUNT);
+    private int openMenuCount;
 
     public ThroughputMonitorTerminalPart(IPartItem<?> partItem) {
         super(partItem, true);
@@ -50,7 +51,7 @@ public class ThroughputMonitorTerminalPart extends AbstractDisplayPart
     @Override
     public void addToWorld() {
         super.addToWorld();
-        registerStorageTracker();
+        updateStorageTracker();
     }
 
     @Override
@@ -104,7 +105,7 @@ public class ThroughputMonitorTerminalPart extends AbstractDisplayPart
 
     @Override
     protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        registerStorageTracker();
+        updateStorageTracker();
         super.onMainNodeStateChanged(reason);
     }
 
@@ -126,6 +127,25 @@ public class ThroughputMonitorTerminalPart extends AbstractDisplayPart
     List<ThroughputMonitorCollector.Snapshot> getSnapshots() {
         registerStorageTracker();
         return collector.getSnapshots();
+    }
+
+    void openMonitor() {
+        openMenuCount++;
+        registerStorageTracker();
+    }
+
+    void closeMonitor() {
+        if (openMenuCount > 0 && --openMenuCount == 0) {
+            unregisterStorageTracker();
+        }
+    }
+
+    private void updateStorageTracker() {
+        if (openMenuCount > 0) {
+            registerStorageTracker();
+        } else {
+            unregisterStorageTracker();
+        }
     }
 
     private void registerStorageTracker() {

--- a/src/main/java/org/gtlcore/gtlcore/integration/jade/GTLJadePlugin.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jade/GTLJadePlugin.java
@@ -25,6 +25,7 @@ public class GTLJadePlugin implements IWailaPlugin {
         registration.registerFluidStorage(MEStockingFluidStorageProvider.INSTANCE, MetaMachineBlockEntity.class);
         registration.registerBlockDataProvider(new WirelessOpticalDataHatchProvide(), BlockEntity.class);
         registration.registerBlockDataProvider(new TickTimeProvider(), MetaMachineBlockEntity.class);
+        registration.registerBlockDataProvider(new BatchProcessingProvider(), MetaMachineBlockEntity.class);
         registration.registerBlockDataProvider(new MEPatternBufferProvider(), BlockEntity.class);
         registration.registerBlockDataProvider(new MEPatternBufferProxyProvider(), BlockEntity.class);
         registration.registerBlockDataProvider(new MEMAIOProvider(), BlockEntity.class);
@@ -43,6 +44,7 @@ public class GTLJadePlugin implements IWailaPlugin {
         registration.registerFluidStorageClient(MEStockingFluidStorageProvider.INSTANCE);
         registration.registerBlockComponent(new WirelessOpticalDataHatchProvide(), Block.class);
         registration.registerBlockComponent(new TickTimeProvider(), MetaMachineBlock.class);
+        registration.registerBlockComponent(new BatchProcessingProvider(), MetaMachineBlock.class);
         registration.registerBlockComponent(new MEPatternBufferProvider(), Block.class);
         registration.registerBlockComponent(new MEPatternBufferProxyProvider(), Block.class);
         registration.registerBlockComponent(new MEMAIOProvider(), Block.class);

--- a/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/BatchProcessingProvider.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/BatchProcessingProvider.java
@@ -1,0 +1,55 @@
+package org.gtlcore.gtlcore.integration.jade.provider;
+
+import org.gtlcore.gtlcore.GTLCore;
+import org.gtlcore.gtlcore.api.recipe.IGTRecipe;
+
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
+import com.gregtechceu.gtceu.integration.jade.provider.CapabilityBlockProvider;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import org.jetbrains.annotations.Nullable;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+public class BatchProcessingProvider extends CapabilityBlockProvider<IRecipeLogicMachine> {
+
+    private static final String BATCH_SIZE_TAG = "batch_size";
+
+    public BatchProcessingProvider() {
+        super(GTLCore.id("batch_processing_provider"));
+    }
+
+    @Nullable
+    @Override
+    protected IRecipeLogicMachine getCapability(Level level, BlockPos pos, @Nullable Direction side) {
+        return MetaMachine.getMachine(level, pos) instanceof IRecipeLogicMachine machine ? machine : null;
+    }
+
+    @Override
+    protected void write(CompoundTag data, IRecipeLogicMachine capability) {
+        var recipeLogic = capability.getRecipeLogic();
+        if (!recipeLogic.isActive()) return;
+        var recipe = recipeLogic.getLastRecipe();
+        if (recipe != null && IGTRecipe.of(recipe).getBatchSize() > 1) {
+            data.putInt(BATCH_SIZE_TAG, IGTRecipe.of(recipe).getBatchSize());
+        }
+    }
+
+    @Override
+    protected void addTooltip(CompoundTag capData, ITooltip tooltip, Player player, BlockAccessor block,
+                              BlockEntity blockEntity, IPluginConfig config) {
+        int batchSize = capData.getInt(BATCH_SIZE_TAG);
+        if (batchSize > 1) {
+            tooltip.add(Component.translatable("gui.gtlcore.batch_processing.active", batchSize));
+        }
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/PatternRelayJadeProvider.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/PatternRelayJadeProvider.java
@@ -4,16 +4,22 @@ import org.gtlcore.gtlcore.GTLCore;
 import org.gtlcore.gtlcore.integration.ae2.patternrelay.PatternRelayPart;
 
 import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 
 import appeng.blockentity.networking.CableBusBlockEntity;
+import appeng.util.SettingsFrom;
+import org.jetbrains.annotations.Nullable;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.IBlockComponentProvider;
 import snownee.jade.api.ITooltip;
 import snownee.jade.api.config.IPluginConfig;
+import snownee.jade.api.ui.IElement;
+import snownee.jade.api.ui.IElementHelper;
 
 public final class PatternRelayJadeProvider implements IBlockComponentProvider {
 
@@ -21,23 +27,44 @@ public final class PatternRelayJadeProvider implements IBlockComponentProvider {
     private static final String MODE_TOOLTIP_KEY = "tooltip.gtlcore.me_pattern_relay.mode";
 
     @Override
+    public IElement getIcon(BlockAccessor accessor, IPluginConfig config, IElement defaultIcon) {
+        PatternRelayPart relay = getTargetedRelay(accessor);
+        if (relay == null) {
+            return defaultIcon;
+        }
+
+        ItemStack stack = new ItemStack(relay.getPartItem());
+        CompoundTag settings = new CompoundTag();
+        relay.exportSettings(SettingsFrom.DISMANTLE_ITEM, settings);
+        if (!settings.isEmpty()) {
+            stack.setTag(settings);
+        }
+        return IElementHelper.get().item(stack);
+    }
+
+    @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
-        if (!(accessor.getBlockEntity() instanceof CableBusBlockEntity cableBus)) {
-            return;
-        }
-
-        BlockHitResult hitResult = accessor.getHitResult();
-        if (hitResult == null) {
-            return;
-        }
-
-        Vec3 hitInBlock = hitResult.getLocation().subtract(Vec3.atLowerCornerOf(accessor.getPosition()));
-        if (cableBus.getCableBus().selectPartLocal(hitInBlock).part instanceof PatternRelayPart relay) {
+        PatternRelayPart relay = getTargetedRelay(accessor);
+        if (relay != null) {
             tooltip.add(Component.translatable(
                     MODE_TOOLTIP_KEY,
                     Component.translatable(relay.getModeNameTranslationKey()))
                     .withStyle(ChatFormatting.GRAY));
         }
+    }
+
+    private static @Nullable PatternRelayPart getTargetedRelay(BlockAccessor accessor) {
+        if (!(accessor.getBlockEntity() instanceof CableBusBlockEntity cableBus)) {
+            return null;
+        }
+
+        BlockHitResult hitResult = accessor.getHitResult();
+        if (hitResult == null) {
+            return null;
+        }
+
+        Vec3 hitInBlock = hitResult.getLocation().subtract(Vec3.atLowerCornerOf(accessor.getPosition()));
+        return cableBus.getCableBus().selectPartLocal(hitInBlock).part instanceof PatternRelayPart relay ? relay : null;
     }
 
     @Override

--- a/src/main/java/org/gtlcore/gtlcore/mixin/avaritia/client/InfinityArmorModelMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/avaritia/client/InfinityArmorModelMixin.java
@@ -1,0 +1,33 @@
+package org.gtlcore.gtlcore.mixin.avaritia.client;
+
+import committee.nova.mods.avaritia.client.model.InfinityArmorModel;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Group;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(InfinityArmorModel.class)
+public abstract class InfinityArmorModelMixin {
+
+    @Group(name = "suppressWingMaterialLog", min = 1, max = 1)
+    @Redirect(
+              method = "renderToBuffer(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;IIFFFF)V",
+              at = @At(
+                       value = "INVOKE",
+                       target = "Lorg/apache/logging/log4j/Logger;info(Ljava/lang/Object;)V",
+                       remap = false),
+              require = 0)
+    private void gtlcore$suppressWingMaterialLog(Logger logger, Object message) {}
+
+    @Group(name = "suppressWingMaterialLog", min = 1, max = 1)
+    @Redirect(
+              method = "m_7695_(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;IIFFFF)V",
+              at = @At(
+                       value = "INVOKE",
+                       target = "Lorg/apache/logging/log4j/Logger;info(Ljava/lang/Object;)V",
+                       remap = false),
+              require = 0,
+              remap = false)
+    private void gtlcore$suppressObfuscatedWingMaterialLog(Logger logger, Object message) {}
+}

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/machine/MetaMachineMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/machine/MetaMachineMixin.java
@@ -3,6 +3,7 @@ package org.gtlcore.gtlcore.mixin.gtm.api.machine;
 import org.gtlcore.gtlcore.api.machine.IPerformanceDisplayMachine;
 import org.gtlcore.gtlcore.api.machine.ISuspendableMachine;
 import org.gtlcore.gtlcore.api.machine.PerformanceMonitorMachine;
+import org.gtlcore.gtlcore.api.machine.trait.IBatchMachine;
 
 import com.gregtechceu.gtceu.api.block.BlockProperties;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
@@ -164,14 +165,55 @@ public abstract class MetaMachineMixin implements IPerformanceDisplayMachine, IS
         }
     }
 
+    @Inject(method = "onToolClick", at = @At("HEAD"), remap = false, cancellable = true)
+    private void gtlcore$toggleBatchProcessingWithWireCutter(Set<@NotNull GTToolType> toolTypes, ItemStack itemStack,
+                                                             UseOnContext context,
+                                                             CallbackInfoReturnable<Pair<GTToolType, InteractionResult>> cir) {
+        Player player = context.getPlayer();
+        MetaMachine machine = holder.getMetaMachine();
+        if (!toolTypes.contains(GTToolType.WIRE_CUTTER) || player == null || !player.isShiftKeyDown() ||
+                !(machine instanceof IBatchMachine batchMachine) ||
+                !batchMachine.canConfigureBatchProcessing())
+            return;
+
+        InteractionResult result = player instanceof ServerPlayer serverPlayer ?
+                gtlcore$toggleBatchProcessing(serverPlayer, context.getHand(), batchMachine) :
+                InteractionResult.SUCCESS;
+        cir.setReturnValue(Pair.of(GTToolType.WIRE_CUTTER, result));
+    }
+
     @Inject(method = "onToolClick", at = @At("RETURN"), remap = false, cancellable = true)
-    private void onToolClick(Set<@NotNull GTToolType> toolType, ItemStack itemStack, UseOnContext context, CallbackInfoReturnable<Pair<GTToolType, InteractionResult>> cir) {
-        if (cir.getReturnValue().getSecond() == InteractionResult.PASS && toolType.contains(GTToolType.WIRE_CUTTER)) {
-            Player player = context.getPlayer();
-            if (player instanceof ServerPlayer serverPlayer && holder.getMetaMachine() instanceof IGridConnectedMachine gridConnectedMachine) {
-                cir.setReturnValue(Pair.of(GTToolType.WIRE_CUTTER, gTLCore$onWireCutterClick(serverPlayer, context.getHand(), gridConnectedMachine)));
-            }
+    private void gtlcore$configureGridWithWireCutter(Set<@NotNull GTToolType> toolTypes, ItemStack itemStack,
+                                                     UseOnContext context,
+                                                     CallbackInfoReturnable<Pair<GTToolType, InteractionResult>> cir) {
+        if (cir.getReturnValue().getSecond() != InteractionResult.PASS ||
+                !toolTypes.contains(GTToolType.WIRE_CUTTER))
+            return;
+
+        Player player = context.getPlayer();
+        MetaMachine machine = holder.getMetaMachine();
+        if (player instanceof ServerPlayer serverPlayer && machine instanceof IGridConnectedMachine gridConnectedMachine) {
+            cir.setReturnValue(Pair.of(GTToolType.WIRE_CUTTER,
+                    gTLCore$onWireCutterClick(serverPlayer, context.getHand(), gridConnectedMachine)));
         }
+    }
+
+    @Unique
+    private InteractionResult gtlcore$toggleBatchProcessing(ServerPlayer serverPlayer, InteractionHand hand,
+                                                            IBatchMachine batchMachine) {
+        serverPlayer.swing(hand);
+        if (!batchMachine.supportsBatchProcessing()) {
+            serverPlayer.sendSystemMessage(
+                    Component.translatable("gui.gtlcore.batch_processing.unsupported_mode"), true);
+            return InteractionResult.CONSUME;
+        }
+
+        boolean enabled = !batchMachine.isBatchEnabled();
+        batchMachine.setBatchEnabled(enabled);
+        serverPlayer.sendSystemMessage(Component.translatable(enabled ?
+                "gui.gtlcore.batch_processing.enabled" :
+                "gui.gtlcore.batch_processing.disabled"), true);
+        return InteractionResult.CONSUME;
     }
 
     @Inject(method = "shouldRenderGrid", at = @At("HEAD"), remap = false, cancellable = true)

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/machine/RecipeLogicMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/machine/RecipeLogicMixin.java
@@ -3,6 +3,7 @@ package org.gtlcore.gtlcore.mixin.gtm.api.machine;
 import org.gtlcore.gtlcore.api.machine.ISuspendableMachine;
 import org.gtlcore.gtlcore.api.machine.trait.ILockRecipe;
 import org.gtlcore.gtlcore.api.machine.trait.IRecipeStatus;
+import org.gtlcore.gtlcore.api.recipe.BatchProcessing;
 import org.gtlcore.gtlcore.api.recipe.IGTRecipe;
 import org.gtlcore.gtlcore.api.recipe.RecipeResult;
 
@@ -27,6 +28,8 @@ import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.*;
 import java.util.function.Predicate;
@@ -116,6 +119,7 @@ public abstract class RecipeLogicMixin implements ILockRecipe, IRecipeStatus {
     @Overwrite(remap = false)
     protected boolean handleRecipeIO(GTRecipe recipe, IO io) {
         if (!(this.machine.hasProxies() && io != IO.BOTH)) return false;
+        if (io == IO.IN && !BatchProcessing.applyInPlace(this.machine.self(), recipe)) return false;
         return handleRecipeInput(this.machine, recipe);
     }
 
@@ -167,6 +171,22 @@ public abstract class RecipeLogicMixin implements ILockRecipe, IRecipeStatus {
             this.duration = recipe.duration;
             this.isActive = true;
         }
+    }
+
+    @Redirect(
+              method = "serverTick",
+              at = @At(
+                       value = "INVOKE",
+                       target = "Lcom/gregtechceu/gtceu/api/machine/trait/RecipeLogic;onRecipeFinish()V",
+                       remap = false),
+              remap = false)
+    private void gtlcore$finishRecipeWhenBatchOutputFits(RecipeLogic recipeLogic) {
+        if (this.lastRecipe != null && IGTRecipe.of(this.lastRecipe).getBatchSize() > 1 &&
+                !matchRecipeOutput(this.machine, this.lastRecipe)) {
+            this.setWaiting(null);
+            return;
+        }
+        recipeLogic.onRecipeFinish();
     }
 
     /**
@@ -271,6 +291,11 @@ public abstract class RecipeLogicMixin implements ILockRecipe, IRecipeStatus {
      */
     @Overwrite(remap = false)
     public void onRecipeFinish() {
+        if (this.lastRecipe != null && IGTRecipe.of(this.lastRecipe).getBatchSize() > 1 &&
+                !matchRecipeOutput(this.machine, this.lastRecipe)) {
+            this.setWaiting(null);
+            return;
+        }
         this.machine.afterWorking();
         if (this.lastRecipe != null) {
             handleRecipeOutput(this.machine, this.lastRecipe);

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/pattern/BlockPatternMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/pattern/BlockPatternMixin.java
@@ -1,5 +1,6 @@
 package org.gtlcore.gtlcore.mixin.gtm.api.pattern;
 
+import org.gtlcore.gtlcore.api.pattern.AdvancedBlockPattern;
 import org.gtlcore.gtlcore.api.pattern.util.IMultiblockStateGet;
 
 import com.gregtechceu.gtceu.api.block.ActiveBlock;
@@ -24,6 +25,7 @@ import it.unimi.dsi.fastutil.objects.*;
 import org.spongepowered.asm.mixin.*;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -67,101 +69,141 @@ public abstract class BlockPatternMixin {
      */
     @Overwrite(remap = false)
     public boolean checkPatternAt(MultiblockState worldState, BlockPos centerPos, Direction frontFacing, Direction upwardsFacing, boolean isFlipped, boolean savePredicate) {
-        boolean findFirstAisle = false;
-        int minZ = -centerOffset[4];
-        if (worldState instanceof IMultiblockStateGet stateGet) stateGet.cleanState();
-        PatternMatchContext matchContext = worldState.getMatchContext();
-        Map<SimplePredicate, Integer> globalCount = worldState.getGlobalCount();
-        Map<SimplePredicate, Integer> layerCount = worldState.getLayerCount();
+        int[] matchedRepetitions = new int[this.fingerLength];
+        int minStartZ = -this.centerOffset[4];
+        int maxStartZ = -this.centerOffset[3];
+        for (int startZ = minStartZ; startZ <= maxStartZ; startZ++) {
+            Arrays.fill(matchedRepetitions, 0);
+            if (gtlcore$matchAisles(worldState, centerPos, frontFacing, upwardsFacing, isFlipped, savePredicate,
+                    startZ, 0, startZ, matchedRepetitions)) {
+                worldState.setError(null);
+                worldState.setNeededFlip(isFlipped);
+                PatternMatchContext matchContext = worldState.getMatchContext();
+                matchContext.set(AdvancedBlockPattern.MATCHED_REPETITIONS_CONTEXT, matchedRepetitions.clone());
+                matchContext.set(AdvancedBlockPattern.MATCHED_MIN_Z_CONTEXT, startZ);
+                return true;
+            }
+            if (worldState.error == MultiblockState.UNLOAD_ERROR) return false;
+        }
 
-        // Checking aisles
-        for (int c = 0, z = minZ++, r; c < this.fingerLength; c++) {
-            // Checking repeatable slices
-            loop:
-            for (r = 0; (findFirstAisle ? r < aisleRepetitions[c][1] : z <= -centerOffset[3]); r++) {
-                // Checking single slice
-                layerCount.clear();
+        if (!worldState.hasError()) worldState.setError(new PatternError());
+        return false;
+    }
 
-                for (int b = 0, y = -centerOffset[1]; b < this.thumbLength; b++, y++) {
-                    for (int a = 0, x = -centerOffset[0]; a < this.palmLength; a++, x++) {
-                        worldState.setError(null);
-                        TraceabilityPredicate predicate = this.blockMatches[c][b][a];
-                        if (predicate.isAny()) continue;
-                        BlockPos pos = setActualRelativeOffset(x, y, z, frontFacing, upwardsFacing, isFlipped).offset(centerPos.getX(),
-                                centerPos.getY(), centerPos.getZ());
-                        if (worldState instanceof IMultiblockStateGet stateGet && !stateGet.updateState(pos, predicate)) {
-                            return false;
-                        }
-                        if (predicate.addCache()) {
-                            worldState.addPosCache(pos);
-                            if (savePredicate) {
-                                matchContext.getOrCreate("predicates", Object2ObjectOpenHashMap::new).put(pos, predicate);
-                            }
-                        }
-                        boolean canPartShared = true;
-                        if (worldState.getTileEntity() instanceof IMachineBlockEntity machineBlockEntity &&
-                                machineBlockEntity.getMetaMachine() instanceof IMultiPart part) { // add detected parts
-                            if (!predicate.isAny()) {
-                                if (part.isFormed() && !part.canShared() &&
-                                        !part.hasController(worldState.controllerPos)) { // check part can be shared
-                                    canPartShared = false;
-                                    worldState.setError(new PatternStringError("multiblocked.pattern.error.share"));
-                                } else {
-                                    matchContext.getOrCreate("parts", ObjectOpenHashSet::new).add(part);
-                                }
-                            }
-                        }
-                        if (worldState.getBlockState().getBlock() instanceof ActiveBlock) {
-                            matchContext.getOrCreate("vaBlocks", LongOpenHashSet::new)
-                                    .add(worldState.getPos().asLong());
-                        }
-                        if (!predicate.test(worldState) || !canPartShared) { // matching failed
-                            if (findFirstAisle) {
-                                if (r < aisleRepetitions[c][0]) {// retreat to see if the first aisle can start later
-                                    r = c = 0;
-                                    z = minZ++;
-                                    matchContext.reset();
-                                    findFirstAisle = false;
-                                }
-                            } else {
-                                z++;// continue searching for the first aisle
-                            }
-                            continue loop;
-                        }
-                        matchContext.getOrCreate("ioMap", Long2ObjectOpenHashMap::new).put(worldState.getPos().asLong(),
-                                worldState.io);
-                    }
+    @Unique
+    private boolean gtlcore$matchAisles(MultiblockState worldState, BlockPos centerPos, Direction frontFacing,
+                                        Direction upwardsFacing, boolean isFlipped, boolean savePredicate, int startZ,
+                                        int aisle, int z, int[] repetitions) {
+        if (aisle == 0 && worldState instanceof IMultiblockStateGet stateGet) stateGet.cleanState();
+
+        int minRepetitions = this.aisleRepetitions[aisle][0];
+        int maxRepetitions = this.aisleRepetitions[aisle][1];
+        int validRepetitions = 0;
+        while (validRepetitions < maxRepetitions &&
+                gtlcore$matchSlice(worldState, centerPos, frontFacing, upwardsFacing, isFlipped, savePredicate, aisle,
+                        z + validRepetitions)) {
+            validRepetitions++;
+        }
+        if (worldState.error == MultiblockState.UNLOAD_ERROR) return false;
+
+        for (int count = validRepetitions; count >= minRepetitions; count--) {
+            repetitions[aisle] = count;
+            Arrays.fill(repetitions, aisle + 1, repetitions.length, 0);
+            if (!gtlcore$replayLayout(worldState, centerPos, frontFacing, upwardsFacing, isFlipped, savePredicate,
+                    startZ, aisle, repetitions)) {
+                if (worldState.error == MultiblockState.UNLOAD_ERROR) return false;
+                continue;
+            }
+            if (aisle + 1 < this.fingerLength) {
+                if (gtlcore$matchAisles(worldState, centerPos, frontFacing, upwardsFacing, isFlipped, savePredicate,
+                        startZ, aisle + 1, z + count, repetitions)) {
+                    return true;
                 }
-                findFirstAisle = true;
-                z++;
+                if (worldState.error == MultiblockState.UNLOAD_ERROR) return false;
+            } else if (gtlcore$hasRequiredGlobalCounts(worldState)) {
+                return true;
+            }
+        }
+        repetitions[aisle] = 0;
+        return false;
+    }
 
-                // Check layer-local matcher predicate
-                for (var entry : layerCount.entrySet()) {
-                    if (entry.getValue() < entry.getKey().minLayerCount) {
-                        worldState.setError(new SinglePredicateError(entry.getKey(), 3));
-                        return false;
-                    }
+    @Unique
+    private boolean gtlcore$replayLayout(MultiblockState worldState, BlockPos centerPos, Direction frontFacing,
+                                         Direction upwardsFacing, boolean isFlipped, boolean savePredicate, int startZ,
+                                         int lastAisle, int[] repetitions) {
+        if (!(worldState instanceof IMultiblockStateGet stateGet)) return false;
+        stateGet.cleanState();
+        int z = startZ;
+        for (int aisle = 0; aisle <= lastAisle; aisle++) {
+            for (int repeat = 0; repeat < repetitions[aisle]; repeat++, z++) {
+                if (!gtlcore$matchSlice(worldState, centerPos, frontFacing, upwardsFacing, isFlipped, savePredicate,
+                        aisle, z)) {
+                    return false;
                 }
             }
-            // Repetitions out of range
-            if (r < aisleRepetitions[c][0] || worldState.hasError() || !findFirstAisle) {
-                if (!worldState.hasError()) {
-                    worldState.setError(new PatternError());
+        }
+        return true;
+    }
+
+    @Unique
+    private boolean gtlcore$matchSlice(MultiblockState worldState, BlockPos centerPos, Direction frontFacing,
+                                       Direction upwardsFacing, boolean isFlipped, boolean savePredicate, int aisle,
+                                       int z) {
+        Map<SimplePredicate, Integer> layerCount = worldState.getLayerCount();
+        layerCount.clear();
+        PatternMatchContext matchContext = worldState.getMatchContext();
+        for (int b = 0, y = -this.centerOffset[1]; b < this.thumbLength; b++, y++) {
+            for (int a = 0, x = -this.centerOffset[0]; a < this.palmLength; a++, x++) {
+                worldState.setError(null);
+                TraceabilityPredicate predicate = this.blockMatches[aisle][b][a];
+                if (predicate.isAny()) continue;
+                BlockPos pos = setActualRelativeOffset(x, y, z, frontFacing, upwardsFacing, isFlipped)
+                        .offset(centerPos.getX(), centerPos.getY(), centerPos.getZ());
+                if (!(worldState instanceof IMultiblockStateGet stateGet) || !stateGet.updateState(pos, predicate)) {
+                    return false;
                 }
+                if (predicate.addCache()) {
+                    worldState.addPosCache(pos);
+                    if (savePredicate) {
+                        matchContext.getOrCreate("predicates", Object2ObjectOpenHashMap::new).put(pos, predicate);
+                    }
+                }
+                boolean canPartShared = true;
+                if (worldState.getTileEntity() instanceof IMachineBlockEntity machineBlockEntity &&
+                        machineBlockEntity.getMetaMachine() instanceof IMultiPart part) {
+                    if (part.isFormed() && !part.canShared() && !part.hasController(worldState.controllerPos)) {
+                        canPartShared = false;
+                        worldState.setError(new PatternStringError("multiblocked.pattern.error.share"));
+                    } else {
+                        matchContext.getOrCreate("parts", ObjectOpenHashSet::new).add(part);
+                    }
+                }
+                if (worldState.getBlockState().getBlock() instanceof ActiveBlock) {
+                    matchContext.getOrCreate("vaBlocks", LongOpenHashSet::new).add(worldState.getPos().asLong());
+                }
+                if (!predicate.test(worldState) || !canPartShared) return false;
+                matchContext.getOrCreate("ioMap", Long2ObjectOpenHashMap::new).put(worldState.getPos().asLong(),
+                        worldState.io);
+            }
+        }
+        for (var entry : layerCount.entrySet()) {
+            if (entry.getValue() < entry.getKey().minLayerCount) {
+                worldState.setError(new SinglePredicateError(entry.getKey(), 3));
                 return false;
             }
         }
+        return true;
+    }
 
-        // Check count matches amount
-        for (var entry : globalCount.entrySet()) {
+    @Unique
+    private boolean gtlcore$hasRequiredGlobalCounts(MultiblockState worldState) {
+        for (var entry : worldState.getGlobalCount().entrySet()) {
             if (entry.getValue() < entry.getKey().minCount) {
                 worldState.setError(new SinglePredicateError(entry.getKey(), 1));
                 return false;
             }
         }
-
-        worldState.setError(null);
-        worldState.setNeededFlip(isFlipped);
         return true;
     }
 

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/recipe/GTRecipeMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/recipe/GTRecipeMixin.java
@@ -36,6 +36,14 @@ public abstract class GTRecipeMixin implements IGTRecipe {
     @Getter
     private long realParallels = 1;
     @Unique
+    @Getter
+    @Setter
+    private int batchSize = 1;
+    @Unique
+    @Getter
+    @Setter
+    private boolean batchProcessed;
+    @Unique
     @Setter
     private boolean hasTick;
     @Unique

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/recipe/ParallelLogicMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/recipe/ParallelLogicMixin.java
@@ -1,5 +1,6 @@
 package org.gtlcore.gtlcore.mixin.gtm.api.recipe;
 
+import org.gtlcore.gtlcore.api.recipe.BatchProcessing;
 import org.gtlcore.gtlcore.api.recipe.IGTRecipe;
 import org.gtlcore.gtlcore.api.recipe.IParallelLogic;
 
@@ -76,7 +77,9 @@ public abstract class ParallelLogicMixin {
             if (limitByOutput > 1) {
                 GTRecipe multiRecipe = currentRecipe.copy(ContentModifier.multiplier(limitByOutput), modifyDuration);
                 ((IGTRecipe) multiRecipe).setRealParallels((long) limitByOutput * ((IGTRecipe) currentRecipe).getRealParallels());
-                multiRecipe = IParallelLogic.getRecipeOutputChance(machine, multiRecipe);
+                if (!BatchProcessing.isEnabled(machine.self())) {
+                    multiRecipe = IParallelLogic.getRecipeOutputChance(machine, multiRecipe);
+                }
                 return Pair.of(multiRecipe, limitByOutput);
             } else {
                 return Pair.of(currentRecipe, limitByOutput);

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/recipe/RecipeModifierListMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/recipe/RecipeModifierListMixin.java
@@ -1,5 +1,6 @@
 package org.gtlcore.gtlcore.mixin.gtm.api.recipe;
 
+import org.gtlcore.gtlcore.api.recipe.BatchProcessing;
 import org.gtlcore.gtlcore.api.recipe.IAdvancedOCResult;
 import org.gtlcore.gtlcore.utils.NumberUtils;
 
@@ -96,6 +97,6 @@ public abstract class RecipeModifierListMixin {
         }
 
         result.reset();
-        return modifiedRecipe;
+        return modifiedRecipe == null ? null : BatchProcessing.apply(machine, modifiedRecipe);
     }
 }

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/fix/WorkableElectricMultiblockMachineMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/fix/WorkableElectricMultiblockMachineMixin.java
@@ -1,9 +1,12 @@
 package org.gtlcore.gtlcore.mixin.gtm.fix;
 
+import org.gtlcore.gtlcore.api.machine.trait.IBatchMachine;
 import org.gtlcore.gtlcore.api.machine.trait.ICheckPatternMachine;
 import org.gtlcore.gtlcore.api.machine.trait.ILockRecipe;
 import org.gtlcore.gtlcore.api.machine.trait.IRecipeCapabilityMachine;
 import org.gtlcore.gtlcore.api.machine.trait.IRecipeStatus;
+import org.gtlcore.gtlcore.api.recipe.BatchProcessing;
+import org.gtlcore.gtlcore.api.recipe.IGTRecipe;
 import org.gtlcore.gtlcore.api.recipe.RecipeText;
 
 import com.gregtechceu.gtceu.api.GTValues;
@@ -17,22 +20,35 @@ import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.misc.EnergyContainerList;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.machine.multiblock.electric.research.DataBankMachine;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Mixin(WorkableElectricMultiblockMachine.class)
-public abstract class WorkableElectricMultiblockMachineMixin extends WorkableMultiblockMachine implements IFancyUIMachine, ICheckPatternMachine {
+public abstract class WorkableElectricMultiblockMachineMixin extends WorkableMultiblockMachine implements IFancyUIMachine, ICheckPatternMachine, IBatchMachine {
+
+    @Unique
+    private static final String GTLCORE_BATCH_ENABLED_NBT = "GTLCoreBatchEnabled";
+
+    @Unique
+    @Getter
+    private boolean batchEnabled = false;
 
     public WorkableElectricMultiblockMachineMixin(IMachineBlockEntity holder, Object... args) {
         super(holder, args);
@@ -78,6 +94,48 @@ public abstract class WorkableElectricMultiblockMachineMixin extends WorkableMul
     }
 
     @Override
+    public void setBatchEnabled(boolean enabled) {
+        boolean nextState = enabled && supportsBatchProcessing();
+        if (this.batchEnabled == nextState) return;
+        this.batchEnabled = nextState;
+        this.markDirty();
+        this.getRecipeLogic().markLastRecipeDirty();
+        this.getRecipeLogic().updateTickSubscription();
+    }
+
+    @Override
+    public void saveCustomPersistedData(@NotNull CompoundTag tag, boolean forDrop) {
+        super.saveCustomPersistedData(tag, forDrop);
+        tag.putBoolean(GTLCORE_BATCH_ENABLED_NBT, this.batchEnabled);
+    }
+
+    @Override
+    public void loadCustomPersistedData(@NotNull CompoundTag tag) {
+        super.loadCustomPersistedData(tag);
+        if (tag.contains(GTLCORE_BATCH_ENABLED_NBT, Tag.TAG_BYTE)) {
+            this.batchEnabled = tag.getBoolean(GTLCORE_BATCH_ENABLED_NBT);
+        }
+    }
+
+    @Override
+    public boolean supportsBatchProcessing() {
+        return gtlcore$hasBaseBatchSupport() && !BatchProcessing.isCrossRecipeParallel(this);
+    }
+
+    @Override
+    public boolean canConfigureBatchProcessing() {
+        return gtlcore$hasBaseBatchSupport() && BatchProcessing.canConfigureBatchProcessing(this);
+    }
+
+    @Unique
+    private boolean gtlcore$hasBaseBatchSupport() {
+        var recipeTypes = getDefinition().getRecipeTypes();
+        return !isGenerator() && !(self() instanceof IOpticalComputationReceiver) &&
+                !(self() instanceof IOpticalComputationProvider) && !(self() instanceof DataBankMachine) &&
+                recipeTypes != null && Arrays.stream(recipeTypes).anyMatch(type -> type != GTRecipeTypes.DUMMY_RECIPES);
+    }
+
+    @Override
     public void attachConfigurators(ConfiguratorPanel configuratorPanel) {
         configuratorPanel.attachConfigurators(new IFancyConfiguratorButton.Toggle(
                 GuiTextures.BUTTON_POWER.getSubTexture(0, 0, 1, 0.5),
@@ -111,6 +169,11 @@ public abstract class WorkableElectricMultiblockMachineMixin extends WorkableMul
             } else {
                 textList.add(Component.translatable("gui.gtlcore.recipe_lock.no_recipe"));
             }
+        }
+        var activeRecipe = this.getRecipeLogic().getLastRecipe();
+        if (this.getRecipeLogic().isActive() && activeRecipe != null && IGTRecipe.of(activeRecipe).getBatchSize() > 1) {
+            textList.add(Component.translatable("gui.gtlcore.batch_processing.active",
+                    IGTRecipe.of(activeRecipe).getBatchSize()));
         }
     }
 

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/gui/BatchConfiguratorMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/gui/BatchConfiguratorMixin.java
@@ -1,0 +1,36 @@
+package org.gtlcore.gtlcore.mixin.gtm.gui;
+
+import org.gtlcore.gtlcore.api.machine.trait.IBatchMachine;
+
+import com.gregtechceu.gtceu.api.gui.fancy.ConfiguratorPanel;
+import com.gregtechceu.gtceu.api.gui.fancy.FancyMachineUIWidget;
+import com.gregtechceu.gtceu.api.gui.fancy.IFancyUIProvider;
+import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = FancyMachineUIWidget.class, remap = false)
+public abstract class BatchConfiguratorMixin {
+
+    @Shadow
+    @Final
+    protected ConfiguratorPanel configuratorPanel;
+
+    @Inject(
+            method = "setupFancyUI(Lcom/gregtechceu/gtceu/api/gui/fancy/IFancyUIProvider;Z)V",
+            at = @At(
+                     value = "INVOKE",
+                     target = "Lcom/gregtechceu/gtceu/api/gui/fancy/IFancyUIProvider;attachConfigurators(Lcom/gregtechceu/gtceu/api/gui/fancy/ConfiguratorPanel;)V",
+                     shift = At.Shift.AFTER))
+    private void gtlcore$attachBatchConfigurator(IFancyUIProvider page, boolean hasPlayerInventory,
+                                                 CallbackInfo ci) {
+        if (page instanceof WorkableElectricMultiblockMachine machine) {
+            IBatchMachine.attachBatchConfigurator(configuratorPanel, machine);
+        }
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/syncdata/GTRecipePayloadMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/syncdata/GTRecipePayloadMixin.java
@@ -31,6 +31,7 @@ public abstract class GTRecipePayloadMixin extends ObjectTypedPayload<GTRecipe> 
         tag.putString("id", payload.id.toString());
         tag.put("recipe", GTRecipeSerializer.CODEC.encodeStart(NbtOps.INSTANCE, payload).result().orElse(new CompoundTag()));
         tag.putLong("realParallels", IGTRecipe.of(payload).getRealParallels());
+        tag.putInt("batchSize", IGTRecipe.of(payload).getBatchSize());
         tag.putInt("ocTier", payload.ocTier);
         return tag;
     }
@@ -42,6 +43,7 @@ public abstract class GTRecipePayloadMixin extends ObjectTypedPayload<GTRecipe> 
             if (payload != null) {
                 payload.id = new ResourceLocation(compoundTag.getString("id"));
                 IGTRecipe.of(payload).setRealParallels(compoundTag.contains("realParallels") ? compoundTag.getLong("realParallels") : 1);
+                IGTRecipe.of(payload).setBatchSize(compoundTag.contains("batchSize") ? compoundTag.getInt("batchSize") : 1);
                 payload.ocTier = compoundTag.getInt("ocTier");
             }
         } else if (tag instanceof StringTag stringTag) {
@@ -67,6 +69,7 @@ public abstract class GTRecipePayloadMixin extends ObjectTypedPayload<GTRecipe> 
         buf.writeResourceLocation(this.payload.id);
         GTRecipeSerializer.SERIALIZER.toNetwork(buf, this.payload);
         buf.writeLong(IGTRecipe.of(this.payload).getRealParallels());
+        buf.writeInt(IGTRecipe.of(this.payload).getBatchSize());
         buf.writeInt(this.payload.ocTier);
     }
 
@@ -77,7 +80,10 @@ public abstract class GTRecipePayloadMixin extends ObjectTypedPayload<GTRecipe> 
             this.payload = GTRecipeSerializer.SERIALIZER.fromNetwork(id, buf);
             if (buf.isReadable()) {
                 IGTRecipe.of(this.payload).setRealParallels(buf.readLong());
-                this.payload.ocTier = buf.readInt();
+                if (buf.isReadable()) {
+                    IGTRecipe.of(this.payload).setBatchSize(buf.readInt());
+                    this.payload.ocTier = buf.readInt();
+                }
             }
         } else {
             RecipeManager recipeManager = Registries.getRecipeManager();

--- a/src/main/resources/assets/gtlcore/lang/en_us.json
+++ b/src/main/resources/assets/gtlcore/lang/en_us.json
@@ -100,6 +100,9 @@
   "config.gtlcore.option.ae2PatternProviderAutoExpandDefault": "Enable Smart Multiplication for newly placed AE2 Pattern Providers by default",
   "config.gtlcore.option.enablePrimitiveVoidOre": "Enable Primitive Void Ore Miner",
   "config.gtlcore.option.enableMaxFastCalculationLogging": "Enable MAX_FAST Calculation Performance Logging",
+  "config.gtlcore.option.enableAe2CraftingDispatchPerformanceLogging": "Enable AE2 Crafting Dispatch Performance Logging",
+  "config.gtlcore.option.ae2CraftingDispatchPerformanceWarningMicros": "AE2 Crafting Dispatch Performance Warning Threshold (Microseconds)",
+  "config.gtlcore.option.ae2CraftingDispatchPerformanceLogIntervalTicks": "AE2 Crafting Dispatch Performance Log Interval (Ticks)",
   "config.gtlcore.option.enableSkyBlokeMode": "Enable Skyblock Mode",
   "config.gtlcore.option.enableSmoothAnimations": "Enable Smooth Animations",
   "config.gtlcore.option.enableUltimateMEStocking": "Enable Ultimate ME Stocking Pull Mode",
@@ -115,6 +118,7 @@
   "config.gtlcore.option.travelStaffCD": "Travel Staff Cooldown",
   "config.gtlcore.option.ftbUltimineRange": "Chain Mining Range",
   "config.gtlcore.option.sendUpdateMessages": "Enable Update Notifications",
+  "config.gtlcore.option.batchProcessingTimeLimitTicks": "Batch Processing Time Limit (Ticks)",
   "config.jade.plugin_gtlcore.tick_time_provider": "[GTLCore] Tick Time",
   "config.jade.plugin_gtlcore.wireless_data_hatch_provider": "Wireless Data Hatch",
   "config.jade.plugin_gtlcore.wireless_ae_network_provider": "Wireless ME Network",
@@ -613,5 +617,9 @@
   "gui.gtlcore.transfinite_computation_array.selection_mode.player_only.tooltip": "Players only: accepts player-sourced requests and is preferred over general-purpose CPUs",
   "gui.gtlcore.transfinite_computation_array.selection_mode.machine_only.tooltip": "Automation only: accepts requests without a player source and is preferred over general-purpose CPUs",
   "gui.gtlcore.transfinite_computation_array.parallelism": "Dispatch parallelism",
-  "gui.gtlcore.transfinite_computation_array.storage": "Aggregate crafting storage: Unlimited"
+  "gui.gtlcore.transfinite_computation_array.storage": "Aggregate crafting storage: Unlimited",
+  "gui.gtlcore.batch_processing.enabled": "Batch processing: Enabled",
+  "gui.gtlcore.batch_processing.disabled": "Batch processing: Disabled",
+  "gui.gtlcore.batch_processing.unsupported_mode": "Batch processing: Unsupported in the current machine mode",
+  "gui.gtlcore.batch_processing.active": "Current batch: %s cycles"
 }

--- a/src/main/resources/assets/gtlcore/lang/zh_cn.json
+++ b/src/main/resources/assets/gtlcore/lang/zh_cn.json
@@ -100,6 +100,9 @@
   "config.gtlcore.option.ae2PatternProviderAutoExpandDefault": "新放置的AE2样板供应器默认开启智能翻倍",
   "config.gtlcore.option.enablePrimitiveVoidOre": "启用原始虚空矿机",
   "config.gtlcore.option.enableMaxFastCalculationLogging": "启用MAX_FAST计算性能日志",
+  "config.gtlcore.option.enableAe2CraftingDispatchPerformanceLogging": "启用AE2合成发配性能日志",
+  "config.gtlcore.option.ae2CraftingDispatchPerformanceWarningMicros": "AE2合成发配性能警告阈值（微秒）",
+  "config.gtlcore.option.ae2CraftingDispatchPerformanceLogIntervalTicks": "AE2合成发配性能日志间隔（Tick）",
   "config.gtlcore.option.enableSkyBlokeMode": "启用空岛模式",
   "config.gtlcore.option.enableSmoothAnimations": "启用平滑渲染",
   "config.gtlcore.option.enableUltimateMEStocking": "启用ME库存极限拉取模式",
@@ -115,6 +118,7 @@
   "config.gtlcore.option.travelStaffCD": "旅行权杖CD",
   "config.gtlcore.option.ftbUltimineRange": "连锁挖掘检查范围",
   "config.gtlcore.option.sendUpdateMessages": "是否启用更新提醒",
+  "config.gtlcore.option.batchProcessingTimeLimitTicks": "批处理时间上限（Tick）",
   "config.jade.plugin_gtlcore.tick_time_provider": "[GTLCore] Tick时间",
   "config.jade.plugin_gtlcore.wireless_data_hatch_provider": "无线数据仓",
   "config.jade.plugin_gtlcore.wireless_ae_network_provider": "无线 ME 网络",
@@ -613,5 +617,9 @@
   "gui.gtlcore.transfinite_computation_array.selection_mode.player_only.tooltip": "仅玩家下单：只接受带玩家来源的请求，并优先于通用 CPU",
   "gui.gtlcore.transfinite_computation_array.selection_mode.machine_only.tooltip": "仅自动化系统：只接受无玩家来源的请求，并优先于通用 CPU",
   "gui.gtlcore.transfinite_computation_array.parallelism": "发配并行数",
-  "gui.gtlcore.transfinite_computation_array.storage": "合成存储总量：无限"
+  "gui.gtlcore.transfinite_computation_array.storage": "合成存储总量：无限",
+  "gui.gtlcore.batch_processing.enabled": "批处理：已启用",
+  "gui.gtlcore.batch_processing.disabled": "批处理：已禁用",
+  "gui.gtlcore.batch_processing.unsupported_mode": "批处理：当前机器模式不支持",
+  "gui.gtlcore.batch_processing.active": "当前批次：%s 个周期"
 }

--- a/src/main/resources/gtlcore.mixin.json
+++ b/src/main/resources/gtlcore.mixin.json
@@ -4,6 +4,7 @@
   "package": "org.gtlcore.gtlcore.mixin",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "avaritia.client.InfinityArmorModelMixin",
     "ae2.client.BuiltInModelHooksAccessor",
     "ae2.client.ModelBakeryMixin",
     "ae2.gui.NumberEntryWidgetAccessor",
@@ -175,6 +176,7 @@
     "gtm.fix.WorkableElectricMultiblockMachineMixin",
     "gtm.ftb.TeleportFromMapPacketMixin",
     "gtm.gui.AmountSetWidgetMixin",
+    "gtm.gui.BatchConfiguratorMixin",
     "gtm.gui.GTRecipeWidgetMixin",
     "gtm.gui.MachineModeFancyConfiguratorMixin",
     "gtm.gui.ProspectorScannerBehaviorMixin",


### PR DESCRIPTION
## 改动

- 为 GTM 多方块机器添加可选批处理，默认时间上限为 100 tick。
- 根据材料、处理时间及 Long.MAX_VALUE 限制自动计算批次数。
- 支持状态持久化、Jade 批次显示和剪线钳快捷开关。
- 隐藏不支持批处理的机器按钮，并增强批处理的兼容性。
- 修复超限演算阵列加载及重复结构检查问题。
- 优化 ME 库存查询和吞吐监控性能。
- 修复 Jade 中 ME 样板中继器图标与实际模式不一致。
- 屏蔽 Avaritia 无限盔甲材质日志。
- 补齐相关配置的中英文本地化。