### PR TITLE
feat: improve AE2 integration and crafting workflows

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/client/gui/widget/AEDualConfigSlotWidget.java
+++ b/src/main/java/org/gtlcore/gtlcore/client/gui/widget/AEDualConfigSlotWidget.java
@@ -1,6 +1,7 @@
 package org.gtlcore.gtlcore.client.gui.widget;
 
 import org.gtlcore.gtlcore.integration.ae2.MEFluidUnits;
+import org.gtlcore.gtlcore.integration.jei.JeiMissingIngredientBookmarks;
 import org.gtlcore.gtlcore.utils.Registries;
 
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
@@ -10,6 +11,7 @@ import com.gregtechceu.gtceu.integration.ae2.slot.IConfigurableSlot;
 import com.gregtechceu.gtceu.integration.ae2.utils.AEUtil;
 
 import com.lowdragmc.lowdraglib.LDLib;
+import com.lowdragmc.lowdraglib.gui.ingredient.IIngredientSlot;
 import com.lowdragmc.lowdraglib.gui.ingredient.Target;
 import com.lowdragmc.lowdraglib.gui.util.DrawerHelper;
 import com.lowdragmc.lowdraglib.gui.util.TextFormattingUtil;
@@ -49,7 +51,7 @@ import static com.lowdragmc.lowdraglib.gui.widget.PhantomFluidWidget.drainFrom;
 /**
  * @author EasterFG on 2025/3/7
  */
-public class AEDualConfigSlotWidget extends Widget implements IGhostItemTarget, IGhostFluidTarget {
+public class AEDualConfigSlotWidget extends Widget implements IGhostItemTarget, IGhostFluidTarget, IIngredientSlot {
 
     private static final int COMPACT_AMOUNT_MAX_LENGTH = 4;
 
@@ -114,6 +116,26 @@ public class AEDualConfigSlotWidget extends Widget implements IGhostItemTarget, 
     protected boolean mouseOverStock(double mouseX, double mouseY) {
         Position position = getPosition();
         return isMouseOver(position.x, position.y + 18, 18, 18, mouseX, mouseY);
+    }
+
+    @Override
+    public Object getXEIIngredientOverMouse(double mouseX, double mouseY) {
+        boolean configHovered = mouseOverConfig(mouseX, mouseY);
+        boolean stockHovered = mouseOverStock(mouseX, mouseY);
+        if (!configHovered && !stockHovered) {
+            return null;
+        }
+
+        IConfigurableSlot slot = parentWidget.getDisplay(getIndex());
+        GenericStack stack = configHovered ? slot.getConfig() : slot.getStock();
+        if (stack == null) {
+            return null;
+        }
+
+        int slotHeight = getSizeHeight() / 2;
+        int slotY = getPositionY() + (stockHovered ? slotHeight : 0);
+        var area = new Rect2i(getPositionX(), slotY, getSizeWidth(), slotHeight);
+        return JeiMissingIngredientBookmarks.createClickableIngredient(stack.what(), area).orElse(null);
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/org/gtlcore/gtlcore/config/ConfigHolder.java
+++ b/src/main/java/org/gtlcore/gtlcore/config/ConfigHolder.java
@@ -78,6 +78,20 @@ public class ConfigHolder {
     @Configurable.Range(min = 1, max = 16)
     public int ae2StorageServiceUpdateInterval = 8;
     @Configurable
+    @Configurable.Comment({
+            "测试功能：玩家进入手动合成结算界面后，锁定该计划使用的ME库存，直至取消、关闭界面或订单提交。",
+            "Experimental: Reserve ME inventory used by a manual crafting plan until it is cancelled, closed, or submitted."
+    })
+    public boolean enableAe2ManualCraftingInventoryLock = false;
+    @Configurable
+    @Configurable.Comment({
+            "测试功能：将手动合成库存锁的申请、冲突、提取限制、提交和释放效果写入独立日志。",
+            "日志文件：logs/gtlcore/ae2-manual-crafting-inventory-lock-*.log",
+            "Experimental: Write manual crafting inventory lock acquisition, conflicts, extraction limits, submission, and release effects to a dedicated log.",
+            "Log file: logs/gtlcore/ae2-manual-crafting-inventory-lock-*.log"
+    })
+    public boolean enableAe2ManualCraftingInventoryLockLogging = false;
+    @Configurable
     @Configurable.Comment("AE2合成计算模式: LEGACY(原版), FAST(快速), ULTRA_FAST(极快), MAX_FAST(需求聚合)")
     public AE2CalculationMode ae2CalculationMode = AE2CalculationMode.ULTRA_FAST;
     @Configurable

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/WirelessTerminalGridResolver.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/WirelessTerminalGridResolver.java
@@ -1,5 +1,7 @@
 package org.gtlcore.gtlcore.integration.ae2;
 
+import org.gtlcore.gtlcore.integration.ae2.wireless.CuriosCompat;
+
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -26,16 +28,24 @@ public final class WirelessTerminalGridResolver {
 
     public static @Nullable IGrid find(Player player, Level level) {
         IItemHandler handler = player.getCapability(ForgeCapabilities.ITEM_HANDLER).resolve().orElse(null);
-        if (handler == null) {
-            return null;
+        if (handler != null) {
+            IGrid grid = find(
+                    player,
+                    handler,
+                    level,
+                    Collections.newSetFromMap(new IdentityHashMap<>()),
+                    new SearchBudget(MAX_NESTED_HANDLER_DEPTH, MAX_SCANNED_SLOTS),
+                    0);
+            if (grid != null) {
+                return grid;
+            }
         }
-        return find(
-                player,
-                handler,
-                level,
-                Collections.newSetFromMap(new IdentityHashMap<>()),
-                new SearchBudget(MAX_NESTED_HANDLER_DEPTH, MAX_SCANNED_SLOTS),
-                0);
+
+        CuriosCompat.TerminalSlot curiosSlot = CuriosCompat.findWirelessTerminal(player);
+        if (curiosSlot != null && curiosSlot.stack().getItem() instanceof WirelessTerminalItem terminal) {
+            return findUsableGrid(player, level, curiosSlot.stack(), terminal);
+        }
+        return null;
     }
 
     private static @Nullable IGrid find(Player player, IItemHandler handler, Level level, Set<IItemHandler> visited,

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/ManualCraftingInventoryLock.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/ManualCraftingInventoryLock.java
@@ -1,0 +1,191 @@
+package org.gtlcore.gtlcore.integration.ae2.crafting;
+
+import appeng.api.networking.crafting.ICraftingSubmitResult;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.KeyCounter;
+import appeng.api.storage.MEStorage;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/** Keeps manually planned crafting ingredients unavailable to other network extractions. */
+public final class ManualCraftingInventoryLock {
+
+    private static final Map<MEStorage, KeyCounter> RESERVED = new WeakHashMap<>();
+    private static final ThreadLocal<Reservation> ACTIVE_SUBMISSION = new ThreadLocal<>();
+    private static final AtomicLong NEXT_RESERVATION_ID = new AtomicLong();
+
+    private ManualCraftingInventoryLock() {}
+
+    public static @Nullable Reservation tryAcquire(MEStorage storage, KeyCounter requested, IActionSource source) {
+        var available = new KeyCounter();
+        storage.getAvailableStacks(available);
+
+        Reservation reservation = null;
+        AEKey conflictKey = null;
+        long conflictRequested = 0;
+        long conflictAvailable = 0;
+        long conflictReserved = 0;
+        synchronized (RESERVED) {
+            var reserved = RESERVED.get(storage);
+            for (var entry : requested) {
+                long alreadyReserved = reserved == null ? 0 : reserved.get(entry.getKey());
+                long availableToReserve = subtractClamped(available.get(entry.getKey()), alreadyReserved);
+                if (entry.getLongValue() > availableToReserve) {
+                    conflictKey = entry.getKey();
+                    conflictRequested = entry.getLongValue();
+                    conflictAvailable = availableToReserve;
+                    conflictReserved = alreadyReserved;
+                    break;
+                }
+            }
+
+            if (conflictKey == null) {
+                var owned = new KeyCounter();
+                owned.addAll(requested);
+                if (!owned.isEmpty()) {
+                    if (reserved == null) {
+                        reserved = new KeyCounter();
+                        RESERVED.put(storage, reserved);
+                    }
+                    reserved.addAll(owned);
+                }
+                reservation = new Reservation(NEXT_RESERVATION_ID.incrementAndGet(), storage, owned);
+            }
+        }
+
+        if (reservation == null) {
+            ManualCraftingInventoryLockLogger.conflict(
+                    storage, conflictKey, conflictRequested, conflictAvailable, conflictReserved, source);
+        } else {
+            ManualCraftingInventoryLockLogger.acquired(reservation.id, storage, reservation.amounts, source);
+        }
+        return reservation;
+    }
+
+    public static boolean hasReservations(MEStorage storage) {
+        synchronized (RESERVED) {
+            var reserved = RESERVED.get(storage);
+            return reserved != null && !reserved.isEmpty();
+        }
+    }
+
+    public static long limitExtraction(MEStorage storage, AEKey what, long requested, IActionSource source) {
+        if (requested <= 0) {
+            return requested;
+        }
+
+        long reservedForOthers;
+        synchronized (RESERVED) {
+            var reserved = RESERVED.get(storage);
+            if (reserved == null) {
+                return requested;
+            }
+
+            long totalReserved = reserved.get(what);
+            var active = ACTIVE_SUBMISSION.get();
+            long owned = active != null && active.isActiveFor(storage) ? active.amounts.get(what) : 0;
+            reservedForOthers = subtractClamped(totalReserved, owned);
+        }
+
+        if (reservedForOthers <= 0) {
+            return requested;
+        }
+
+        long available = storage instanceof AvailabilityView view ?
+                view.gtlcore$getAvailableAmount(what, source) : getAvailableAmount(storage, what);
+        long extractable = subtractClamped(available, reservedForOthers);
+        long allowed = Math.min(requested, extractable);
+        if (allowed < requested) {
+            ManualCraftingInventoryLockLogger.extractionLimited(
+                    storage, what, requested, allowed, available, reservedForOthers, source);
+        }
+        return allowed;
+    }
+
+    private static long getAvailableAmount(MEStorage storage, AEKey what) {
+        var available = new KeyCounter();
+        storage.getAvailableStacks(available);
+        return available.get(what);
+    }
+
+    private static long subtractClamped(long value, long deduction) {
+        return value <= deduction ? 0 : value - deduction;
+    }
+
+    public interface AvailabilityView {
+
+        long gtlcore$getAvailableAmount(AEKey what, IActionSource source);
+    }
+
+    public static final class Reservation implements AutoCloseable {
+
+        private final long id;
+        private final MEStorage storage;
+        private final KeyCounter amounts;
+        private boolean active = true;
+
+        private Reservation(long id, MEStorage storage, KeyCounter amounts) {
+            this.id = id;
+            this.storage = storage;
+            this.amounts = amounts;
+        }
+
+        public ICraftingSubmitResult submit(Supplier<ICraftingSubmitResult> action) {
+            if (!this.active) {
+                return action.get();
+            }
+
+            var previous = ACTIVE_SUBMISSION.get();
+            ACTIVE_SUBMISSION.set(this);
+            try {
+                ICraftingSubmitResult result = action.get();
+                ManualCraftingInventoryLockLogger.submitted(this.id, result);
+                return result;
+            } catch (RuntimeException | Error exception) {
+                ManualCraftingInventoryLockLogger.submissionFailed(this.id, exception);
+                throw exception;
+            } finally {
+                if (previous == null) {
+                    ACTIVE_SUBMISSION.remove();
+                } else {
+                    ACTIVE_SUBMISSION.set(previous);
+                }
+            }
+        }
+
+        private boolean isActiveFor(MEStorage storage) {
+            return this.active && this.storage == storage;
+        }
+
+        @Override
+        public void close() {
+            boolean released = false;
+            synchronized (RESERVED) {
+                if (!this.active) {
+                    return;
+                }
+                this.active = false;
+
+                var reserved = RESERVED.get(this.storage);
+                if (reserved == null) {
+                    released = true;
+                } else {
+                    reserved.removeAll(this.amounts);
+                    reserved.removeZeros();
+                    if (reserved.isEmpty()) {
+                        RESERVED.remove(this.storage);
+                    }
+                    released = true;
+                }
+            }
+            if (released) {
+                ManualCraftingInventoryLockLogger.released(this.id, this.storage, this.amounts);
+            }
+        }
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/ManualCraftingInventoryLockLogger.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/ManualCraftingInventoryLockLogger.java
@@ -1,0 +1,251 @@
+package org.gtlcore.gtlcore.integration.ae2.crafting;
+
+import org.gtlcore.gtlcore.config.ConfigHolder;
+
+import net.minecraftforge.fml.loading.FMLPaths;
+
+import appeng.api.networking.crafting.ICraftingSubmitResult;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.KeyCounter;
+import appeng.api.storage.MEStorage;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.StringJoiner;
+
+public final class ManualCraftingInventoryLockLogger {
+
+    private static final String LOGGER_NAME = "gtlcore.ae2.manual_crafting.inventory_lock";
+    private static final String APPENDER_NAME_PREFIX = "GTLCoreManualCraftingInventoryLock-";
+    private static final String MINECRAFT_LOG_DIRECTORY = "logs";
+    private static final String LOG_DIRECTORY = "gtlcore";
+    private static final String LOG_FILE_PREFIX = "ae2-manual-crafting-inventory-lock-";
+    private static final String LOG_FILE_EXTENSION = ".log";
+    private static final String ROLLOVER_FILE_SUFFIX = "-%i.log.gz";
+    private static final String TIMESTAMP_PATTERN = "yyyy-MM-dd_HH-mm-ss-SSS";
+    private static final String LOG_LAYOUT = "%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %msg%n";
+    private static final String ROLLOVER_SIZE = "16 MB";
+    private static final String ROLLOVER_FILE_COUNT = "4";
+
+    private static final Object INITIALIZATION_LOCK = new Object();
+    private static volatile Logger logger;
+    private static volatile String activeAppenderName;
+    private static volatile boolean initializationFailed;
+
+    private ManualCraftingInventoryLockLogger() {}
+
+    public static boolean isEnabled() {
+        return ConfigHolder.INSTANCE != null &&
+                ConfigHolder.INSTANCE.enableAe2ManualCraftingInventoryLockLogging;
+    }
+
+    public static void acquired(long reservationId, MEStorage storage, KeyCounter amounts, IActionSource source) {
+        if (!isEnabled()) return;
+        info("event=ACQUIRED reservation={} storage={} source={} keys={} amounts={}",
+                reservationId, storageId(storage), sourceDescription(source), amounts.size(), summarize(amounts));
+    }
+
+    public static void conflict(MEStorage storage, AEKey what, long requested, long available,
+                                long alreadyReserved, IActionSource source) {
+        if (!isEnabled()) return;
+        info("event=CONFLICT storage={} source={} key={} requested={} availableToReserve={} alreadyReserved={}",
+                storageId(storage), sourceDescription(source), what, requested, available, alreadyReserved);
+    }
+
+    public static void extractionLimited(MEStorage storage, AEKey what, long requested, long allowed,
+                                         long physicalAvailable, long reservedForOthers, IActionSource source) {
+        if (!isEnabled()) return;
+        info("event=EXTRACTION_LIMITED storage={} key={} requested={} allowed={} blocked={} physicalAvailable={} reservedForOthers={} source={}",
+                storageId(storage), what, requested, allowed, requested - allowed, physicalAvailable,
+                reservedForOthers, sourceDescription(source));
+    }
+
+    public static void submitted(long reservationId, ICraftingSubmitResult result) {
+        if (!isEnabled()) return;
+        info("event=SUBMITTED reservation={} successful={} error={} detail={}",
+                reservationId, result.successful(), result.errorCode(), result.errorDetail());
+    }
+
+    public static void submissionFailed(long reservationId, Throwable exception) {
+        if (!isEnabled()) return;
+        info("event=SUBMISSION_EXCEPTION reservation={} exception={}", reservationId, exception);
+    }
+
+    public static void released(long reservationId, MEStorage storage, KeyCounter amounts) {
+        if (!isEnabled()) return;
+        info("event=RELEASED reservation={} storage={} keys={} amounts={}",
+                reservationId, storageId(storage), amounts.size(), summarize(amounts));
+    }
+
+    private static void info(String message, Object... arguments) {
+        if (!isEnabled()) {
+            return;
+        }
+        try {
+            Logger dedicatedLogger = getLogger();
+            if (dedicatedLogger != null) {
+                dedicatedLogger.info(message, arguments);
+            }
+        } catch (Throwable ignored) {
+            disableDedicatedLogger();
+        }
+    }
+
+    private static String summarize(KeyCounter amounts) {
+        if (!isEnabled()) {
+            return "";
+        }
+        var summary = new StringJoiner(",", "[", "]");
+        for (var entry : amounts) {
+            summary.add(entry.getKey() + "=" + entry.getLongValue());
+        }
+        return summary.toString();
+    }
+
+    private static String storageId(MEStorage storage) {
+        return Integer.toHexString(System.identityHashCode(storage));
+    }
+
+    private static String sourceDescription(IActionSource source) {
+        return source == null ? "none" : source.player()
+                .map(player -> player.getGameProfile().getName())
+                .orElseGet(() -> source.machine().map(machine -> machine.getClass().getName()).orElse("unknown"));
+    }
+
+    private static Logger getLogger() {
+        Logger currentLogger = logger;
+        if (currentLogger != null && isDedicatedLoggerConfigured()) {
+            return currentLogger;
+        }
+        if (initializationFailed) {
+            return null;
+        }
+
+        synchronized (INITIALIZATION_LOCK) {
+            if ((logger == null || !isDedicatedLoggerConfigured()) && !initializationFailed) {
+                logger = null;
+                activeAppenderName = null;
+                logger = createLogger();
+            }
+            return logger;
+        }
+    }
+
+    private static Logger createLogger() {
+        Configuration configuration = null;
+        RollingFileAppender appender = null;
+        try {
+            String timestamp = DateTimeFormatter
+                    .ofPattern(TIMESTAMP_PATTERN, Locale.ROOT)
+                    .format(LocalDateTime.now());
+            Path logDirectory = FMLPaths.GAMEDIR.get().resolve(MINECRAFT_LOG_DIRECTORY).resolve(LOG_DIRECTORY);
+            Files.createDirectories(logDirectory);
+            Path logFile = logDirectory.resolve(LOG_FILE_PREFIX + timestamp + LOG_FILE_EXTENSION);
+            String filePattern = logDirectory
+                    .resolve(LOG_FILE_PREFIX + timestamp + ROLLOVER_FILE_SUFFIX)
+                    .toString();
+
+            if (!(LogManager.getContext(false) instanceof LoggerContext context)) {
+                throw new IllegalStateException("Log4j2 core LoggerContext is unavailable");
+            }
+
+            configuration = context.getConfiguration();
+            String appenderName = APPENDER_NAME_PREFIX + timestamp;
+            PatternLayout layout = PatternLayout.newBuilder()
+                    .withConfiguration(configuration)
+                    .withCharset(StandardCharsets.UTF_8)
+                    .withPattern(LOG_LAYOUT)
+                    .build();
+            DefaultRolloverStrategy rolloverStrategy = DefaultRolloverStrategy.newBuilder()
+                    .withConfig(configuration)
+                    .withMax(ROLLOVER_FILE_COUNT)
+                    .build();
+            appender = RollingFileAppender.newBuilder()
+                    .setConfiguration(configuration)
+                    .setName(appenderName)
+                    .setLayout(layout)
+                    .setIgnoreExceptions(false)
+                    .withFileName(logFile.toString())
+                    .withFilePattern(filePattern)
+                    .withAppend(true)
+                    .withCreateOnDemand(false)
+                    .withPolicy(SizeBasedTriggeringPolicy.createPolicy(ROLLOVER_SIZE))
+                    .withStrategy(rolloverStrategy)
+                    .build();
+            if (appender == null) {
+                throw new IllegalStateException("Log4j2 did not create the inventory lock rolling file appender");
+            }
+
+            appender.start();
+            configuration.addAppender(appender);
+            configuration.removeLogger(LOGGER_NAME);
+            LoggerConfig loggerConfig = new LoggerConfig(LOGGER_NAME, Level.INFO, false);
+            loggerConfig.addAppender(appender, Level.INFO, null);
+            configuration.addLogger(LOGGER_NAME, loggerConfig);
+            context.updateLoggers();
+
+            Logger dedicatedLogger = LogManager.getLogger(LOGGER_NAME);
+            activeAppenderName = appenderName;
+            dedicatedLogger.info("event=LOGGER_STARTED file={} rolloverSize={} rolloverFiles={}",
+                    logFile.toAbsolutePath(), ROLLOVER_SIZE, ROLLOVER_FILE_COUNT);
+            return dedicatedLogger;
+        } catch (Throwable ignored) {
+            if (configuration != null) {
+                configuration.removeLogger(LOGGER_NAME);
+            }
+            if (appender != null) {
+                appender.stop();
+            }
+            activeAppenderName = null;
+            initializationFailed = true;
+            return null;
+        }
+    }
+
+    private static void disableDedicatedLogger() {
+        synchronized (INITIALIZATION_LOCK) {
+            try {
+                if (LogManager.getContext(false) instanceof LoggerContext context) {
+                    Configuration configuration = context.getConfiguration();
+                    LoggerConfig loggerConfig = configuration.getLoggers().get(LOGGER_NAME);
+                    if (loggerConfig != null) {
+                        loggerConfig.getAppenders().values().forEach(appender -> appender.stop());
+                        configuration.removeLogger(LOGGER_NAME);
+                        context.updateLoggers();
+                    }
+                }
+            } catch (Throwable ignored) {
+                // Diagnostics must never interrupt inventory extraction or crafting submission.
+            } finally {
+                logger = null;
+                activeAppenderName = null;
+                initializationFailed = true;
+            }
+        }
+    }
+
+    private static boolean isDedicatedLoggerConfigured() {
+        String appenderName = activeAppenderName;
+        if (appenderName == null || !(LogManager.getContext(false) instanceof LoggerContext context)) {
+            return false;
+        }
+        LoggerConfig loggerConfig = context.getConfiguration().getLoggers().get(LOGGER_NAME);
+        return loggerConfig != null && !loggerConfig.isAdditive() &&
+                loggerConfig.getAppenders().containsKey(appenderName);
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/patternrelay/PatternRelayPart.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/patternrelay/PatternRelayPart.java
@@ -220,6 +220,10 @@ public final class PatternRelayPart extends AEBasePart implements ICraftingProvi
         return mode.nameTranslationKey;
     }
 
+    public boolean isAccessMode() {
+        return mode == Mode.ACCESS;
+    }
+
     static String getModeNameTranslationKey(ItemStack stack) {
         return getMode(stack.getTag()).nameTranslationKey;
     }

--- a/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/PatternRelayJadeProvider.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jade/provider/PatternRelayJadeProvider.java
@@ -4,27 +4,28 @@ import org.gtlcore.gtlcore.GTLCore;
 import org.gtlcore.gtlcore.integration.ae2.patternrelay.PatternRelayPart;
 
 import net.minecraft.ChatFormatting;
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 
 import appeng.blockentity.networking.CableBusBlockEntity;
-import appeng.util.SettingsFrom;
 import org.jetbrains.annotations.Nullable;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.IBlockComponentProvider;
 import snownee.jade.api.ITooltip;
 import snownee.jade.api.config.IPluginConfig;
+import snownee.jade.api.ui.Element;
 import snownee.jade.api.ui.IElement;
-import snownee.jade.api.ui.IElementHelper;
 
 public final class PatternRelayJadeProvider implements IBlockComponentProvider {
 
     private static final ResourceLocation UID = GTLCore.id("me_pattern_relay_mode");
     private static final String MODE_TOOLTIP_KEY = "tooltip.gtlcore.me_pattern_relay.mode";
+    private static final ResourceLocation SUPPLIER_ICON = GTLCore.id("textures/block/me_pattern_relay_supplier.png");
+    private static final ResourceLocation ACCESS_ICON = GTLCore.id("textures/block/me_pattern_relay_access.png");
 
     @Override
     public IElement getIcon(BlockAccessor accessor, IPluginConfig config, IElement defaultIcon) {
@@ -33,13 +34,7 @@ public final class PatternRelayJadeProvider implements IBlockComponentProvider {
             return defaultIcon;
         }
 
-        ItemStack stack = new ItemStack(relay.getPartItem());
-        CompoundTag settings = new CompoundTag();
-        relay.exportSettings(SettingsFrom.DISMANTLE_ITEM, settings);
-        if (!settings.isEmpty()) {
-            stack.setTag(settings);
-        }
-        return IElementHelper.get().item(stack);
+        return new RelayTextureElement(relay.isAccessMode() ? ACCESS_ICON : SUPPLIER_ICON);
     }
 
     @Override
@@ -65,6 +60,31 @@ public final class PatternRelayJadeProvider implements IBlockComponentProvider {
 
         Vec3 hitInBlock = hitResult.getLocation().subtract(Vec3.atLowerCornerOf(accessor.getPosition()));
         return cableBus.getCableBus().selectPartLocal(hitInBlock).part instanceof PatternRelayPart relay ? relay : null;
+    }
+
+    private static final class RelayTextureElement extends Element {
+
+        private static final float ELEMENT_SIZE = 18.0F;
+        private static final int TEXTURE_SIZE = 16;
+
+        private final ResourceLocation texture;
+
+        private RelayTextureElement(ResourceLocation texture) {
+            this.texture = texture;
+        }
+
+        @Override
+        public Vec2 getSize() {
+            return new Vec2(ELEMENT_SIZE, ELEMENT_SIZE);
+        }
+
+        @Override
+        public void render(GuiGraphics graphics, float x, float y, float maxX, float alpha) {
+            graphics.setColor(1.0F, 1.0F, 1.0F, alpha);
+            graphics.blit(texture, (int) x + 1, (int) y + 1, 0, 0, TEXTURE_SIZE, TEXTURE_SIZE,
+                    TEXTURE_SIZE, TEXTURE_SIZE);
+            graphics.setColor(1.0F, 1.0F, 1.0F, 1.0F);
+        }
     }
 
     @Override

--- a/src/main/java/org/gtlcore/gtlcore/integration/jei/JeiMissingIngredientBookmarks.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/jei/JeiMissingIngredientBookmarks.java
@@ -2,12 +2,16 @@ package org.gtlcore.gtlcore.integration.jei;
 
 import org.gtlcore.gtlcore.GTLCore;
 
+import net.minecraft.client.renderer.Rect2i;
+
 import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.forge.ForgeTypes;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.api.runtime.IClickableIngredient;
 import mezz.jei.api.runtime.IIngredientManager;
 import mezz.jei.api.runtime.IJeiRuntime;
 import org.jetbrains.annotations.Nullable;
@@ -78,6 +82,33 @@ public final class JeiMissingIngredientBookmarks {
             return new AddResult(AddStatus.ADDED, added);
         }
         return new AddResult(supported > 0 ? AddStatus.ALREADY_BOOKMARKED : AddStatus.NOTHING_TO_ADD, 0);
+    }
+
+    public static Optional<IClickableIngredient<?>> createClickableIngredient(AEKey key, Rect2i area) {
+        IJeiRuntime jeiRuntime = runtime;
+        if (jeiRuntime == null) {
+            return Optional.empty();
+        }
+
+        IIngredientManager ingredientManager = jeiRuntime.getIngredientManager();
+        if (key instanceof AEItemKey itemKey) {
+            return createClickableIngredient(
+                    ingredientManager, VanillaTypes.ITEM_STACK, itemKey.toStack(), area);
+        }
+        if (key instanceof AEFluidKey fluidKey) {
+            return createClickableIngredient(
+                    ingredientManager, ForgeTypes.FLUID_STACK, fluidKey.toStack(1), area);
+        }
+        return Optional.empty();
+    }
+
+    private static <T> Optional<IClickableIngredient<?>> createClickableIngredient(
+                                                                                   IIngredientManager ingredientManager,
+                                                                                   IIngredientType<T> type,
+                                                                                   T ingredient,
+                                                                                   Rect2i area) {
+        return ingredientManager.createClickableIngredient(type, ingredient, area, false)
+                .map(clickableIngredient -> clickableIngredient);
     }
 
     private static Optional<ITypedIngredient<?>> toTypedIngredient(AEKey key,

--- a/src/main/java/org/gtlcore/gtlcore/mixin/ae2/crafting/NetworkCraftingSimulationStateMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/ae2/crafting/NetworkCraftingSimulationStateMixin.java
@@ -1,5 +1,7 @@
 package org.gtlcore.gtlcore.mixin.ae2.crafting;
 
+import org.gtlcore.gtlcore.integration.ae2.crafting.ManualCraftingInventoryLock;
+
 import appeng.api.config.Actionable;
 import appeng.api.config.FuzzyMode;
 import appeng.api.networking.security.IActionSource;
@@ -63,8 +65,9 @@ public abstract class NetworkCraftingSimulationStateMixin {
         }
 
         long available = Math.min(cachedAmount, amount);
-        if (AEConfig.instance().isCraftingSimulatedExtraction() && this.gTLCore$storageService != null &&
-                this.gTLCore$actionSource != null) {
+        if (this.gTLCore$storageService != null && this.gTLCore$actionSource != null &&
+                (AEConfig.instance().isCraftingSimulatedExtraction() || ManualCraftingInventoryLock.hasReservations(
+                        this.gTLCore$storageService.getInventory()))) {
             available = this.gTLCore$storageService.getInventory()
                     .extract(what, available, Actionable.SIMULATE, this.gTLCore$actionSource);
         }
@@ -88,7 +91,9 @@ public abstract class NetworkCraftingSimulationStateMixin {
         }
 
         var keys = new ArrayList<AEKey>(fuzzyEntries.size());
-        boolean simulatedExtraction = AEConfig.instance().isCraftingSimulatedExtraction();
+        boolean simulatedExtraction = AEConfig.instance().isCraftingSimulatedExtraction() ||
+                (this.gTLCore$storageService != null &&
+                        ManualCraftingInventoryLock.hasReservations(this.gTLCore$storageService.getInventory()));
         for (var entry : fuzzyEntries) {
             AEKey fuzzyKey = entry.getKey();
             long cachedAmount = entry.getLongValue();

--- a/src/main/java/org/gtlcore/gtlcore/mixin/ae2/gui/CraftConfirmMenuMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/ae2/gui/CraftConfirmMenuMixin.java
@@ -1,9 +1,11 @@
 package org.gtlcore.gtlcore.mixin.ae2.gui;
 
+import org.gtlcore.gtlcore.config.ConfigHolder;
 import org.gtlcore.gtlcore.integration.ae2.common.CraftAmountReturnState;
 import org.gtlcore.gtlcore.integration.ae2.common.IConfirmStartMenu;
 import org.gtlcore.gtlcore.integration.ae2.common.ILongCraftAmountMenu;
 import org.gtlcore.gtlcore.integration.ae2.common.ILongCraftConfirmMenu;
+import org.gtlcore.gtlcore.integration.ae2.crafting.ManualCraftingInventoryLock;
 
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Inventory;
@@ -15,7 +17,12 @@ import appeng.api.config.TypeFilter;
 import appeng.api.config.ViewItems;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.crafting.CalculationStrategy;
+import appeng.api.networking.crafting.ICraftingCPU;
 import appeng.api.networking.crafting.ICraftingPlan;
+import appeng.api.networking.crafting.ICraftingRequester;
+import appeng.api.networking.crafting.ICraftingService;
+import appeng.api.networking.crafting.ICraftingSubmitResult;
+import appeng.api.networking.security.IActionSource;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;
 import appeng.api.storage.ISubMenuHost;
@@ -38,7 +45,9 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -112,6 +121,15 @@ public abstract class CraftConfirmMenuMixin extends AEBaseMenu implements IConfi
 
     @Unique
     private long gtlcore$longAmount = CraftAmountReturnState.NO_LONG_AMOUNT;
+
+    @Unique
+    private @Nullable ManualCraftingInventoryLock.Reservation gtlcore$inventoryReservation;
+
+    @Unique
+    private @Nullable ICraftingPlan gtlcore$reservedPlan;
+
+    @Unique
+    private CalculationStrategy gtlcore$calculationStrategy = CalculationStrategy.REPORT_MISSING_ITEMS;
 
     @Inject(method = "<init>", at = @At("RETURN"), remap = false)
     private void onConstructed(int id, Inventory ip, ISubMenuHost host, CallbackInfo ci) {
@@ -191,6 +209,8 @@ public abstract class CraftConfirmMenuMixin extends AEBaseMenu implements IConfi
 
     @Override
     public boolean gtlcore$planLongAmountJob(AEKey whatToCraft, long amount, CalculationStrategy strategy) {
+        this.gtlcore$releaseInventoryReservation();
+        this.gtlcore$calculationStrategy = strategy;
         if (this.job != null) {
             this.job.cancel(true);
         }
@@ -213,7 +233,14 @@ public abstract class CraftConfirmMenuMixin extends AEBaseMenu implements IConfi
 
     @Inject(method = "broadcastChanges", at = @At("RETURN"))
     private void onBroadcastChanges(CallbackInfo ci) {
-        if (this.plan == null) return;
+        if (this.isClientSide() || this.plan == null) return;
+        if (!ConfigHolder.INSTANCE.enableAe2ManualCraftingInventoryLock) {
+            this.gtlcore$releaseInventoryReservation();
+        } else if (this.result != null && this.result != this.gtlcore$reservedPlan &&
+                !this.gtlcore$tryReserveInventory(this.result)) {
+                    this.gtlcore$restartCalculationAfterReservationConflict();
+                    return;
+                }
         // 计划算完后库存仍可能被其他产线消耗，持续同步实时库存供客户端复核缺失
         if (gtlcore$lastSentStored != null && --gtlcore$storedSyncCooldown > 0) return;
         gtlcore$storedSyncCooldown = 10;
@@ -265,12 +292,89 @@ public abstract class CraftConfirmMenuMixin extends AEBaseMenu implements IConfi
         return relevantStored;
     }
 
+    @Inject(method = "planJob", at = @At("HEAD"), remap = false)
+    private void gtlcore$prepareForPlan(AEKey whatToCraft, int amount, CalculationStrategy strategy,
+                                        CallbackInfoReturnable<Boolean> cir) {
+        this.gtlcore$releaseInventoryReservation();
+        this.gtlcore$calculationStrategy = strategy;
+    }
+
+    @Redirect(
+              method = "startJob",
+              at = @At(
+                       value = "INVOKE",
+                       target = "Lappeng/api/networking/crafting/ICraftingService;submitJob(Lappeng/api/networking/crafting/ICraftingPlan;Lappeng/api/networking/crafting/ICraftingRequester;Lappeng/api/networking/crafting/ICraftingCPU;ZLappeng/api/networking/security/IActionSource;)Lappeng/api/networking/crafting/ICraftingSubmitResult;"),
+              remap = false)
+    private ICraftingSubmitResult gtlcore$submitWithReservedInventory(
+                                                                      ICraftingService craftingService,
+                                                                      ICraftingPlan plan,
+                                                                      ICraftingRequester requester,
+                                                                      ICraftingCPU target,
+                                                                      boolean prioritizePower,
+                                                                      IActionSource source) {
+        var reservation = plan == this.gtlcore$reservedPlan ? this.gtlcore$inventoryReservation : null;
+        ICraftingSubmitResult submitResult = reservation == null ?
+                craftingService.submitJob(plan, requester, target, prioritizePower, source) :
+                reservation.submit(() -> craftingService.submitJob(
+                        plan, requester, target, prioritizePower, source));
+        if (submitResult.successful()) {
+            this.gtlcore$releaseInventoryReservation();
+        }
+        return submitResult;
+    }
+
+    @Inject(method = "removed", at = @At("HEAD"))
+    private void gtlcore$releaseInventoryOnClose(net.minecraft.world.entity.player.Player player, CallbackInfo ci) {
+        this.gtlcore$releaseInventoryReservation();
+    }
+
+    @Unique
+    private boolean gtlcore$tryReserveInventory(ICraftingPlan craftingPlan) {
+        this.gtlcore$releaseInventoryReservation();
+        var grid = this.getGrid();
+        if (grid == null) {
+            return false;
+        }
+
+        var reservation = ManualCraftingInventoryLock.tryAcquire(
+                grid.getStorageService().getInventory(), craftingPlan.usedItems(), this.getActionSource());
+        if (reservation == null) {
+            return false;
+        }
+        this.gtlcore$inventoryReservation = reservation;
+        this.gtlcore$reservedPlan = craftingPlan;
+        return true;
+    }
+
+    @Unique
+    private void gtlcore$restartCalculationAfterReservationConflict() {
+        this.result = null;
+        this.plan = null;
+        this.gtlcore$lastSentStored = null;
+        if (this.whatToCraft == null || !this.gtlcore$planLongAmountJob(
+                this.whatToCraft,
+                CraftAmountReturnState.displayAmount(this.gtlcore$longAmount, this.amount),
+                this.gtlcore$calculationStrategy)) {
+            this.gtlcore$returnToPreviousMenu();
+        }
+    }
+
+    @Unique
+    private void gtlcore$releaseInventoryReservation() {
+        if (this.gtlcore$inventoryReservation != null) {
+            this.gtlcore$inventoryReservation.close();
+            this.gtlcore$inventoryReservation = null;
+        }
+        this.gtlcore$reservedPlan = null;
+    }
+
     @Inject(method = "goBack", at = @At("HEAD"), cancellable = true, remap = false)
     private void goBackWithLongAmount(CallbackInfo ci) {
         if (this.isClientSide()) return;
 
         ci.cancel();
         this.clearError();
+        this.gtlcore$releaseInventoryReservation();
         this.gtlcore$returnToPreviousMenu();
     }
 

--- a/src/main/java/org/gtlcore/gtlcore/mixin/ae2/storage/NetworkStorageMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/ae2/storage/NetworkStorageMixin.java
@@ -1,5 +1,6 @@
 package org.gtlcore.gtlcore.mixin.ae2.storage;
 
+import org.gtlcore.gtlcore.integration.ae2.crafting.ManualCraftingInventoryLock;
 import org.gtlcore.gtlcore.integration.ae2.throughput.ThroughputMonitorStorageTracker;
 import org.gtlcore.gtlcore.integration.ae2.throughput.ThroughputStorageView;
 
@@ -14,6 +15,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
@@ -23,7 +25,7 @@ import java.util.List;
 import java.util.NavigableMap;
 
 @Mixin(NetworkStorage.class)
-public abstract class NetworkStorageMixin implements ThroughputStorageView {
+public abstract class NetworkStorageMixin implements ThroughputStorageView, ManualCraftingInventoryLock.AvailabilityView {
 
     @Shadow(remap = false)
     @Final
@@ -74,6 +76,12 @@ public abstract class NetworkStorageMixin implements ThroughputStorageView {
         ThroughputMonitorStorageTracker.beginExtraction((MEStorage) (Object) this, source);
     }
 
+    @ModifyVariable(method = "extract", at = @At("HEAD"), argsOnly = true, ordinal = 0, remap = false)
+    private long gtlcore$limitExtractionToUnlockedInventory(long amount, AEKey what, long requested,
+                                                            Actionable mode, IActionSource source) {
+        return ManualCraftingInventoryLock.limitExtraction((MEStorage) (Object) this, what, amount, source);
+    }
+
     @Inject(method = "extract", at = @At("RETURN"), remap = false)
     private void gtlcore$recordExtraction(AEKey what, long amount, Actionable mode, IActionSource source, CallbackInfoReturnable<Long> cir) {
         if (!ThroughputMonitorStorageTracker.isTrackingActive() &&
@@ -95,6 +103,22 @@ public abstract class NetworkStorageMixin implements ThroughputStorageView {
             storages.addAll(priorityStorages);
         }
         return storages;
+    }
+
+    @Override
+    public long gtlcore$getAvailableAmount(AEKey what, IActionSource source) {
+        long available = 0;
+        for (List<MEStorage> priorityStorages : priorityInventory.values()) {
+            for (MEStorage storage : priorityStorages) {
+                long remaining = Long.MAX_VALUE - available;
+                long stored = storage.extract(what, remaining, Actionable.SIMULATE, source);
+                if (stored >= remaining) {
+                    return Long.MAX_VALUE;
+                }
+                available += stored;
+            }
+        }
+        return available;
     }
 
     @Override

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/machine/MetaMachineMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/machine/MetaMachineMixin.java
@@ -171,7 +171,7 @@ public abstract class MetaMachineMixin implements IPerformanceDisplayMachine, IS
                                                              CallbackInfoReturnable<Pair<GTToolType, InteractionResult>> cir) {
         Player player = context.getPlayer();
         MetaMachine machine = holder.getMetaMachine();
-        if (!toolTypes.contains(GTToolType.WIRE_CUTTER) || player == null || !player.isShiftKeyDown() ||
+        if (!Set.of(GTToolType.WIRE_CUTTER).equals(toolTypes) || player == null || !player.isShiftKeyDown() ||
                 !(machine instanceof IBatchMachine batchMachine) ||
                 !batchMachine.canConfigureBatchProcessing())
             return;

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/gui/AEConfigSlotWidgetMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/gui/AEConfigSlotWidgetMixin.java
@@ -1,0 +1,52 @@
+package org.gtlcore.gtlcore.mixin.gtm.gui;
+
+import org.gtlcore.gtlcore.integration.jei.JeiMissingIngredientBookmarks;
+
+import com.gregtechceu.gtceu.integration.ae2.gui.widget.ConfigWidget;
+import com.gregtechceu.gtceu.integration.ae2.gui.widget.slot.AEConfigSlotWidget;
+import com.gregtechceu.gtceu.integration.ae2.slot.IConfigurableSlot;
+
+import com.lowdragmc.lowdraglib.gui.ingredient.IIngredientSlot;
+import com.lowdragmc.lowdraglib.gui.widget.Widget;
+
+import net.minecraft.client.renderer.Rect2i;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(value = AEConfigSlotWidget.class, remap = false)
+public abstract class AEConfigSlotWidgetMixin implements IIngredientSlot {
+
+    @Shadow
+    protected ConfigWidget parentWidget;
+
+    @Shadow
+    protected int index;
+
+    @Shadow
+    protected abstract boolean mouseOverConfig(double mouseX, double mouseY);
+
+    @Shadow
+    protected abstract boolean mouseOverStock(double mouseX, double mouseY);
+
+    @Override
+    public Object getXEIIngredientOverMouse(double mouseX, double mouseY) {
+        boolean configHovered = mouseOverConfig(mouseX, mouseY);
+        boolean stockHovered = mouseOverStock(mouseX, mouseY);
+        if (!configHovered && !stockHovered) {
+            return null;
+        }
+
+        IConfigurableSlot slot = parentWidget.getDisplay(index);
+        var stack = configHovered ? slot.getConfig() : slot.getStock();
+        if (stack == null) {
+            return null;
+        }
+
+        Widget widget = (Widget) (Object) this;
+        int slotHeight = widget.getSizeHeight() / 2;
+        int slotY = widget.getPositionY() + (stockHovered ? slotHeight : 0);
+        var area = new Rect2i(widget.getPositionX(), slotY, widget.getSizeWidth(), slotHeight);
+        return JeiMissingIngredientBookmarks.createClickableIngredient(stack.what(), area).orElse(null);
+    }
+}

--- a/src/main/resources/assets/gtlcore/lang/en_us.json
+++ b/src/main/resources/assets/gtlcore/lang/en_us.json
@@ -93,6 +93,8 @@
   "config.gtlcore.option.ae2CalculationMode": "AE2 Calculation Mode",
   "config.gtlcore.option.ae2CraftingServiceUpdateInterval": "AE2 Crafting Update Interval",
   "config.gtlcore.option.ae2StorageServiceUpdateInterval": "AE2 Storage Update Interval",
+  "config.gtlcore.option.enableAe2ManualCraftingInventoryLock": "Lock Manual Crafting Plan Inventory (Experimental)",
+  "config.gtlcore.option.enableAe2ManualCraftingInventoryLockLogging": "Enable Manual Crafting Inventory Lock Effect Logging (Experimental)",
   "config.gtlcore.option.blackBlockList": "FTBU Chain Mining Blacklist",
   "config.gtlcore.option.cellType": "AE Storage Cell Type Multiplier",
   "config.gtlcore.option.disableDrift": "Disable Flight Inertia",

--- a/src/main/resources/assets/gtlcore/lang/zh_cn.json
+++ b/src/main/resources/assets/gtlcore/lang/zh_cn.json
@@ -93,6 +93,8 @@
   "config.gtlcore.option.ae2CalculationMode": "AE2下单计算模式",
   "config.gtlcore.option.ae2CraftingServiceUpdateInterval": "AE2合成更新间隔",
   "config.gtlcore.option.ae2StorageServiceUpdateInterval": "AE2库存更新间隔",
+  "config.gtlcore.option.enableAe2ManualCraftingInventoryLock": "锁定手动合成计划库存（测试功能）",
+  "config.gtlcore.option.enableAe2ManualCraftingInventoryLockLogging": "启用手动合成库存锁效果日志（测试功能）",
   "config.gtlcore.option.blackBlockList": "FTBU连锁黑名单",
   "config.gtlcore.option.cellType": "AE磁盘存储类型倍数",
   "config.gtlcore.option.disableDrift": "禁用飞行惯性",

--- a/src/main/resources/gtlcore.mixin.json
+++ b/src/main/resources/gtlcore.mixin.json
@@ -26,6 +26,7 @@
     "gtm.TagPrefixItemRendererMixin",
     "gtm.api.recipe.ContentMixin",
     "gtm.client.TooltipsHandlerMixin",
+    "gtm.gui.AEConfigSlotWidgetMixin",
     "gtm.gui.AEFluidConfigSlotWidgetMixin",
     "gtm.gui.ConfiguratorPanelMixin",
     "gtm.gui.ConfiguratorPanelTabAccessor",


### PR DESCRIPTION
- 为 AE2 手动合成结算添加可选的库存锁，并在取消、放弃或完成下单时释放库存。
- 添加独立的库存锁效果日志及配置开关，相关选项默认关闭并标注为测试功能。
- 改进 JEI 原料交互与 Curios 无线终端支持。
- 优化样板中继 Jade 显示及批处理工具判断。