### PR TITLE
feat(ae2): 样板中继器继承下游样板供应器/样板总成的翻倍设置

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/CraftingPatternAutoExpand.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/CraftingPatternAutoExpand.java
@@ -4,6 +4,7 @@ import org.gtlcore.gtlcore.api.crafting.IAutoExpandSettings;
 import org.gtlcore.gtlcore.api.machine.trait.AECraft.IMECraftIOPart;
 import org.gtlcore.gtlcore.api.machine.trait.MEPart.IMEPatternPartMachine;
 import org.gtlcore.gtlcore.config.ConfigHolder;
+import org.gtlcore.gtlcore.integration.ae2.patternrelay.PatternRelayPart;
 
 import appeng.api.crafting.IPatternDetails;
 import appeng.api.networking.crafting.ICraftingProvider;
@@ -19,6 +20,11 @@ public final class CraftingPatternAutoExpand {
         }
         if (provider instanceof IMEPatternPartMachine || provider instanceof IMECraftIOPart) {
             return true;
+        }
+        // Pattern relays forward expanded batches to the downstream provider that accepts
+        // them; capacity is negotiated per downstream in gtlcore$getMaxPatternOperations.
+        if (provider instanceof PatternRelayPart relay) {
+            return relay.isAccessMode();
         }
         if (provider instanceof IAutoExpandSettings settings) {
             return settings.isPatternAutoExpand();

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/patternrelay/PatternRelayPart.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/patternrelay/PatternRelayPart.java
@@ -1,6 +1,11 @@
 package org.gtlcore.gtlcore.integration.ae2.patternrelay;
 
 import org.gtlcore.gtlcore.GTLCore;
+import org.gtlcore.gtlcore.api.machine.trait.AECraft.IMECraftIOPart;
+import org.gtlcore.gtlcore.api.machine.trait.MEPart.IMEPatternPartMachine;
+import org.gtlcore.gtlcore.integration.ae2.AEUtils;
+import org.gtlcore.gtlcore.integration.ae2.crafting.IPatternProviderAutoExpand;
+import org.gtlcore.gtlcore.utils.NumberUtils;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -40,6 +45,7 @@ import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import appeng.api.storage.MEStorage;
 import appeng.api.util.AECableType;
+import appeng.helpers.patternprovider.PatternProviderTarget;
 import appeng.parts.AEBasePart;
 import appeng.parts.PartModel;
 import appeng.util.Platform;
@@ -53,7 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public final class PatternRelayPart extends AEBasePart implements ICraftingProvider, IGridTickable {
+public final class PatternRelayPart extends AEBasePart implements ICraftingProvider, IGridTickable, IPatternProviderAutoExpand {
 
     private static final String TAG_MODE = "mode";
     private static final String TAG_PENDING_OUTPUTS = "pendingOutputs";
@@ -242,13 +248,95 @@ public final class PatternRelayPart extends AEBasePart implements ICraftingProvi
             return false;
         }
         Map<AEKey, Long> outputBaselines = captureOutputBaselines(pattern);
-        for (ICraftingProvider provider : providers) {
+        // Prefer providers that can absorb a full (possibly expanded) batch directly:
+        // ME buffers first, then auto-expand capable providers, plain ones last.
+        List<ICraftingProvider> ordered = new ArrayList<>(providers);
+        ordered.sort((a, b) -> Integer.compare(pushPriority(b), pushPriority(a)));
+        for (ICraftingProvider provider : ordered) {
             if (!provider.isBusy() && provider.pushPattern(pattern, inputHolder)) {
-                trackOutputs(pattern, outputBaselines);
+                trackOutputs(pattern, outputBaselines, deriveMultiplier(pattern, inputHolder));
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * The relay never evaluates P2P output targets; expansion is negotiated via
+     * {@link #gtlcore$getMaxPatternOperations} instead.
+     */
+    @Override
+    public long gtlcore$findMaxOperationsForTarget(PatternProviderTarget target, BlockEntity targetBE, Direction side,
+                                                   KeyCounter baseInputs, long requestedOperations) {
+        return 1;
+    }
+
+    private static int pushPriority(ICraftingProvider provider) {
+        if (provider instanceof IMEPatternPartMachine || provider instanceof IMECraftIOPart) {
+            return 2;
+        }
+        return provider instanceof IPatternProviderAutoExpand ? 1 : 0;
+    }
+
+    /**
+     * Smart-doubling support: the relay reports the best operation count any downstream
+     * provider can absorb. ME buffers accept whole batches by design, auto-expand capable
+     * providers report their own capacity (respecting their per-provider switch), and plain
+     * providers stay at 1x. The push itself is safe for every type: full-capacity providers
+     * validate themselves, others fall back to vanilla sendList overflow handling.
+     */
+    @Override
+    public long gtlcore$getMaxPatternOperations(IPatternDetails pattern, long requestedOperations) {
+        if (mode != Mode.ACCESS || requestedOperations <= 1 || !pattern.supportsPushInputsToExternalInventory()) {
+            return 1;
+        }
+        Set<ICraftingProvider> providers = routeSnapshot.routes().get(pattern);
+        if (providers == null || providers.isEmpty()) {
+            return 1;
+        }
+        long max = 1;
+        for (ICraftingProvider provider : providers) {
+            if (provider.isBusy()) {
+                continue;
+            }
+            if (provider instanceof IMEPatternPartMachine || provider instanceof IMECraftIOPart) {
+                return requestedOperations;
+            }
+            if (provider instanceof IPatternProviderAutoExpand expandable) {
+                max = Math.max(max, expandable.gtlcore$getMaxPatternOperations(pattern, requestedOperations));
+            }
+        }
+        return Math.max(1, max);
+    }
+
+    /**
+     * Derives the applied expansion multiplier from the extracted inputs, so output tracking
+     * moves back the correct amount. Programmed circuits are always extracted 1x and must be
+     * ignored here.
+     */
+    private static long deriveMultiplier(IPatternDetails pattern, KeyCounter[] inputHolder) {
+        var inputs = pattern.getInputs();
+        long multiplier = 1;
+        for (int i = 0; i < inputs.length && i < inputHolder.length; i++) {
+            var possibleInputs = inputs[i].getPossibleInputs();
+            if (possibleInputs.length == 0) {
+                continue;
+            }
+            AEKey key = possibleInputs[0].what();
+            if (AEUtils.isIntegratedCircuit(key)) {
+                continue;
+            }
+            long base = inputs[i].getMultiplier();
+            if (base <= 0) {
+                continue;
+            }
+            for (var entry : inputHolder[i]) {
+                if (entry.getKey().equals(key) && entry.getLongValue() > 0) {
+                    multiplier = Math.max(multiplier, entry.getLongValue() / base);
+                }
+            }
+        }
+        return Math.max(1, multiplier);
     }
 
     @Override
@@ -412,14 +500,14 @@ public final class PatternRelayPart extends AEBasePart implements ICraftingProvi
         return baselines;
     }
 
-    private void trackOutputs(IPatternDetails pattern, Map<AEKey, Long> outputBaselines) {
+    private void trackOutputs(IPatternDetails pattern, Map<AEKey, Long> outputBaselines, long multiplier) {
         for (GenericStack output : pattern.getOutputs()) {
             if (output != null && output.amount() > 0) {
                 Long baseline = outputBaselines.get(output.what());
                 if (baseline != null && pendingOutputs.get(output.what()) <= 0) {
                     observedSupplierStock.set(output.what(), baseline);
                 }
-                pendingOutputs.add(output.what(), output.amount());
+                pendingOutputs.add(output.what(), NumberUtils.saturatedMultiply(output.amount(), multiplier));
             }
         }
         getHost().markForSave();


### PR DESCRIPTION
原样板中继器发配时依照主网cpu发配并行数发配原料，限制了下游样板总成的输入速率；
现访问端中继器实现容量协商接口，倍率取下游空闲 provider 的最优值：
ME 总成/IO 全量、可翻倍供应器按其开关与容量计算、未知类型保守 1 倍。
推送优先落在能整批接收的下游；产物回运按实际倍率记账，避免翻倍推送时中继器少搬产物。