### PR TITLE
ME库存输入总成与戴森球的一些修复；为ME库存输入系列的暂停按钮增添实际作用

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/generator/DysonSphereMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/generator/DysonSphereMachine.java
@@ -164,11 +164,11 @@ public class DysonSphereMachine extends WorkableElectricMultiblockMachine {
         int duration = getRecipeLogic().getDuration();
         if (duration <= 0) return value;
 
-        if (!upgradeTriggeredThisRecipe && progress + 1 >= duration && getDysonSphereData() < 10000 && isLaunch(currentRecipe)) {
+        if (!upgradeTriggeredThisRecipe && progress + 1 >= duration && isLaunch(currentRecipe)) {
             upgradeTriggeredThisRecipe = true;
             if (getDysonSpheredamageData() > 60) {
                 this.DysonSpheredamageData = 0;
-            } else {
+            } else if (getDysonSphereData() < 10000) {
                 this.DysonSphereData++;
             }
         }

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualHatchStockPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualHatchStockPartMachine.java
@@ -11,6 +11,7 @@ import org.gtlcore.gtlcore.api.recipe.ingredient.LongIngredient;
 import org.gtlcore.gtlcore.client.gui.widget.AEDualConfigWidget;
 import org.gtlcore.gtlcore.config.ConfigHolder;
 import org.gtlcore.gtlcore.integration.ae2.AEUtils;
+import org.gtlcore.gtlcore.utils.MachineUtil;
 
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
@@ -92,6 +93,7 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
     @Persisted
     protected NotifiableFluidTank fluidTank;
 
+    @DescSynced
     @Setter
     protected int page = 1;
 
@@ -103,6 +105,12 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
     public MEDualHatchStockPartMachine(IMachineBlockEntity holder, Object... args) {
         super(holder, IO.IN, args);
         fluidTank = createTank();
+    }
+
+    @Override
+    public void setWorkingEnabled(boolean workingEnabled) {
+        super.setWorkingEnabled(workingEnabled);
+        MachineUtil.notifyControllersRecipeLogic(this);
     }
 
     @Override
@@ -473,6 +481,9 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
             if (io != IO.IN || left.isEmpty()) {
                 return left;
             }
+            if (!MEDualHatchStockPartMachine.this.isWorkingEnabled()) {
+                return left;
+            }
             IGrid grid = getMainNode().getGrid();
             if (grid == null) {
                 return left;
@@ -564,7 +575,7 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
                 if (this.config != null) {
                     // Extract the items from the real net to either validate (simulate)
                     // or extract (modulate) when this is called
-                    if (!isOnline()) return ItemStack.EMPTY;
+                    if (!isOnline() || !MEDualHatchStockPartMachine.this.isWorkingEnabled()) return ItemStack.EMPTY;
                     IGrid grid = getMainNode().getGrid();
                     if (grid == null) return ItemStack.EMPTY;
                     MEStorage aeNetwork = grid.getStorageService().getInventory();
@@ -647,6 +658,9 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
         @Override
         public List<FluidIngredient> handleRecipeInner(IO io, GTRecipe recipe, List<FluidIngredient> left, @Nullable String slotName, boolean simulate) {
             if (io != IO.IN || left.isEmpty()) {
+                return left;
+            }
+            if (!MEDualHatchStockPartMachine.this.isWorkingEnabled()) {
                 return left;
             }
             IGrid grid = getMainNode().getGrid();
@@ -741,7 +755,7 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
             if (this.stock != null && this.config != null) {
                 // Extract the items from the real net to either validate (simulate)
                 // or extract (modulate) when this is called
-                if (!isOnline()) return FluidStack.empty();
+                if (!isOnline() || !MEDualHatchStockPartMachine.this.isWorkingEnabled()) return FluidStack.empty();
                 IGrid grid = getMainNode().getGrid();
                 if (grid == null) return FluidStack.empty();
                 MEStorage aeNetwork = grid.getStorageService().getInventory();

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualInputHatchPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualInputHatchPartMachine.java
@@ -16,6 +16,7 @@ import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
+import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import com.lowdragmc.lowdraglib.utils.Position;
@@ -47,6 +48,7 @@ public class MEDualInputHatchPartMachine extends MEInputBusPartMachine implement
     @Persisted
     protected NotifiableFluidTank fluidTank;
 
+    @DescSynced
     @Setter
     protected int page = 1;
 

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/TagFilterMEStockBusPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/TagFilterMEStockBusPartMachine.java
@@ -7,6 +7,7 @@ import org.gtlcore.gtlcore.api.machine.trait.MEStock.IMESlot;
 import org.gtlcore.gtlcore.api.machine.trait.MEStock.IOptimizedMEList;
 import org.gtlcore.gtlcore.api.recipe.ingredient.LongIngredient;
 import org.gtlcore.gtlcore.config.ConfigHolder;
+import org.gtlcore.gtlcore.utils.MachineUtil;
 
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.gui.fancy.*;
@@ -75,6 +76,12 @@ public class TagFilterMEStockBusPartMachine extends MEInputBusPartMachine implem
 
     public TagFilterMEStockBusPartMachine(IMachineBlockEntity holder, Object... args) {
         super(holder, args);
+    }
+
+    @Override
+    public void setWorkingEnabled(boolean workingEnabled) {
+        super.setWorkingEnabled(workingEnabled);
+        MachineUtil.notifyControllersRecipeLogic(this);
     }
 
     @Override
@@ -293,6 +300,9 @@ public class TagFilterMEStockBusPartMachine extends MEInputBusPartMachine implem
             if (io != IO.IN || left.isEmpty()) {
                 return left;
             }
+            if (!TagFilterMEStockBusPartMachine.this.isWorkingEnabled()) {
+                return left;
+            }
             IGrid grid = getMainNode().getGrid();
             if (grid == null) {
                 return left;
@@ -382,7 +392,7 @@ public class TagFilterMEStockBusPartMachine extends MEInputBusPartMachine implem
                 if (this.config != null) {
                     // Extract the items from the real net to either validate (simulate)
                     // or extract (modulate) when this is called
-                    if (!isOnline()) return ItemStack.EMPTY;
+                    if (!isOnline() || !TagFilterMEStockBusPartMachine.this.isWorkingEnabled()) return ItemStack.EMPTY;
                     IGrid grid = getMainNode().getGrid();
                     if (grid == null) return ItemStack.EMPTY;
                     MEStorage aeNetwork = grid.getStorageService().getInventory();

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/TagFilterMEStockHatchPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/TagFilterMEStockHatchPartMachine.java
@@ -7,6 +7,7 @@ import org.gtlcore.gtlcore.api.machine.trait.MEStock.IMESlot;
 import org.gtlcore.gtlcore.api.machine.trait.MEStock.IOptimizedMEList;
 import org.gtlcore.gtlcore.config.ConfigHolder;
 import org.gtlcore.gtlcore.integration.ae2.AEUtils;
+import org.gtlcore.gtlcore.utils.MachineUtil;
 
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.gui.fancy.*;
@@ -75,6 +76,12 @@ public class TagFilterMEStockHatchPartMachine extends MEInputHatchPartMachine im
 
     public TagFilterMEStockHatchPartMachine(IMachineBlockEntity holder, Object... args) {
         super(holder, args);
+    }
+
+    @Override
+    public void setWorkingEnabled(boolean workingEnabled) {
+        super.setWorkingEnabled(workingEnabled);
+        MachineUtil.notifyControllersRecipeLogic(this);
     }
 
     @Override
@@ -288,6 +295,9 @@ public class TagFilterMEStockHatchPartMachine extends MEInputHatchPartMachine im
             if (io != IO.IN || left.isEmpty()) {
                 return left;
             }
+            if (!TagFilterMEStockHatchPartMachine.this.isWorkingEnabled()) {
+                return left;
+            }
             IGrid grid = getMainNode().getGrid();
             if (grid == null) {
                 return left;
@@ -371,7 +381,7 @@ public class TagFilterMEStockHatchPartMachine extends MEInputHatchPartMachine im
         @Override
         public FluidStack drain(long maxDrain, boolean simulate, boolean notifyChanges) {
             if (this.stock != null && this.config != null) {
-                if (!isOnline()) return FluidStack.empty();
+                if (!isOnline() || !TagFilterMEStockHatchPartMachine.this.isWorkingEnabled()) return FluidStack.empty();
                 IGrid grid = getMainNode().getGrid();
                 if (grid == null) return FluidStack.empty();
                 MEStorage aeNetwork = grid.getStorageService().getInventory();

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/machine/MEStockingBusPartMachineMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/machine/MEStockingBusPartMachineMixin.java
@@ -2,6 +2,7 @@ package org.gtlcore.gtlcore.mixin.gtm.ae.machine;
 
 import org.gtlcore.gtlcore.api.machine.trait.MEPart.IModifiableSyncOffset;
 import org.gtlcore.gtlcore.api.machine.trait.MEStock.IOptimizedMEList;
+import org.gtlcore.gtlcore.utils.MachineUtil;
 
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
@@ -33,6 +34,12 @@ public abstract class MEStockingBusPartMachineMixin extends MEInputBusPartMachin
 
     public MEStockingBusPartMachineMixin(IMachineBlockEntity holder, IO io, Object... args) {
         super(holder, io, args);
+    }
+
+    @Override
+    public void setWorkingEnabled(boolean workingEnabled) {
+        super.setWorkingEnabled(workingEnabled);
+        MachineUtil.notifyControllersRecipeLogic(this);
     }
 
     @Inject(method = "<init>", at = @At("RETURN"), remap = false)

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/machine/MEStockingHatchPartMachineMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/machine/MEStockingHatchPartMachineMixin.java
@@ -2,6 +2,7 @@ package org.gtlcore.gtlcore.mixin.gtm.ae.machine;
 
 import org.gtlcore.gtlcore.api.machine.trait.MEPart.IModifiableSyncOffset;
 import org.gtlcore.gtlcore.api.machine.trait.MEStock.IOptimizedMEList;
+import org.gtlcore.gtlcore.utils.MachineUtil;
 
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
@@ -32,6 +33,12 @@ public abstract class MEStockingHatchPartMachineMixin extends MEInputHatchPartMa
 
     public MEStockingHatchPartMachineMixin(IMachineBlockEntity holder, Object... args) {
         super(holder, args);
+    }
+
+    @Override
+    public void setWorkingEnabled(boolean workingEnabled) {
+        super.setWorkingEnabled(workingEnabled);
+        MachineUtil.notifyControllersRecipeLogic(this);
     }
 
     @Inject(method = "<init>", at = @At("RETURN"), remap = false)

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/slot/ExportOnlyAEStockingFluidListMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/slot/ExportOnlyAEStockingFluidListMixin.java
@@ -86,6 +86,9 @@ public abstract class ExportOnlyAEStockingFluidListMixin extends ExportOnlyAEFlu
         if (io != IO.IN || left.isEmpty()) {
             return left;
         }
+        if (!this$0.isWorkingEnabled()) {
+            return left;
+        }
         IGrid grid = this$0.getMainNode().getGrid();
         if (grid == null) {
             return left;

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/slot/ExportOnlyAEStockingFluidSlotMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/slot/ExportOnlyAEStockingFluidSlotMixin.java
@@ -2,22 +2,42 @@ package org.gtlcore.gtlcore.mixin.gtm.ae.slot;
 
 import org.gtlcore.gtlcore.api.machine.trait.MEStock.IMESlot;
 
+import com.gregtechceu.gtceu.integration.ae2.machine.MEStockingHatchPartMachine;
 import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAEFluidSlot;
+
+import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
 
 import appeng.api.stacks.GenericStack;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import static com.lowdragmc.lowdraglib.LDLib.isRemote;
 
 @Mixin(targets = "com.gregtechceu.gtceu.integration.ae2.machine.MEStockingHatchPartMachine$ExportOnlyAEStockingFluidSlot", remap = false)
 public abstract class ExportOnlyAEStockingFluidSlotMixin extends ExportOnlyAEFluidSlot implements IMESlot {
 
+    @Shadow(remap = false)
+    @Final
+    private MEStockingHatchPartMachine this$0;
+
     @Setter
     @Getter
     private Runnable onConfigChanged;
+
+    @Inject(method = "drain", at = @At("HEAD"), cancellable = true)
+    private void gtlcore$respectWorkingEnabled(long maxDrain, boolean simulate, boolean notifyChanges,
+                                               CallbackInfoReturnable<FluidStack> cir) {
+        if (!this.this$0.isWorkingEnabled()) {
+            cir.setReturnValue(FluidStack.empty());
+        }
+    }
 
     @Override
     public void setConfig(@Nullable GenericStack config) {

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/slot/ExportOnlyAEStockingItemListMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/slot/ExportOnlyAEStockingItemListMixin.java
@@ -85,6 +85,9 @@ public abstract class ExportOnlyAEStockingItemListMixin extends ExportOnlyAEItem
         if (io != IO.IN || left.isEmpty()) {
             return left;
         }
+        if (!this$0.isWorkingEnabled()) {
+            return left;
+        }
         IGrid grid = this$0.getMainNode().getGrid();
         if (grid == null) {
             return left;

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/slot/ExportOnlyAEStockingItemSlotMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/ae/slot/ExportOnlyAEStockingItemSlotMixin.java
@@ -2,22 +2,42 @@ package org.gtlcore.gtlcore.mixin.gtm.ae.slot;
 
 import org.gtlcore.gtlcore.api.machine.trait.MEStock.IMESlot;
 
+import com.gregtechceu.gtceu.integration.ae2.machine.MEStockingBusPartMachine;
 import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAEItemSlot;
+
+import net.minecraft.world.item.ItemStack;
 
 import appeng.api.stacks.GenericStack;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import static com.lowdragmc.lowdraglib.LDLib.isRemote;
 
 @Mixin(targets = "com.gregtechceu.gtceu.integration.ae2.machine.MEStockingBusPartMachine$ExportOnlyAEStockingItemSlot", remap = false)
 public abstract class ExportOnlyAEStockingItemSlotMixin extends ExportOnlyAEItemSlot implements IMESlot {
 
+    @Shadow(remap = false)
+    @Final
+    private MEStockingBusPartMachine this$0;
+
     @Setter
     @Getter
     private Runnable onConfigChanged;
+
+    @Inject(method = "extractItem", at = @At("HEAD"), cancellable = true)
+    private void gtlcore$respectWorkingEnabled(int slot, int amount, boolean simulate, boolean notifyChanges,
+                                               CallbackInfoReturnable<ItemStack> cir) {
+        if (!this.this$0.isWorkingEnabled()) {
+            cir.setReturnValue(ItemStack.EMPTY);
+        }
+    }
 
     @Override
     public void setConfig(@Nullable GenericStack config) {

--- a/src/main/java/org/gtlcore/gtlcore/utils/MachineUtil.java
+++ b/src/main/java/org/gtlcore/gtlcore/utils/MachineUtil.java
@@ -4,7 +4,10 @@ import org.gtlcore.gtlcore.api.recipe.RecipeResult;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.part.MultiblockPartMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntCircuitIngredient;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
@@ -116,6 +119,19 @@ public class MachineUtil {
             return recipe.handleTickRecipeIO(IO.IN, machine, machine.recipeLogic.getChanceCaches());
         }
         return false;
+    }
+
+    /**
+     * 通知部件的所有控制器重新检查配方逻辑订阅。
+     * 用于库存类（stocking）输入部件的暂停切换：其"库存"即 ME 网络，
+     * 暂停/恢复不会产生本地库存变化通知，需主动唤醒可能已退订休眠的控制器。
+     */
+    public static void notifyControllersRecipeLogic(MultiblockPartMachine part) {
+        for (IMultiController controller : part.getControllers()) {
+            if (controller instanceof IRecipeLogicMachine machine) {
+                machine.getRecipeLogic().updateTickSubscription();
+            }
+        }
     }
 
     public static void createItemEntity(ServerLevel level, double x, double y, double z, ItemStack itemStack) {


### PR DESCRIPTION
fix(ae2): 修复ME输入总成与库存输入总成界面翻页状态服务端与客户端不同步的问题：page 字段补充 @DescSynced，避免非第一页退出后重进界面时页码与实际显示不一致

fix(gt): 修复戴森球发射满后无法重置损坏度的问题

feat(ae2): 为ME库存输入系列部件的暂停按钮增添实际作用
- 库存类部件暂停后配方无法再从ME网络抽料
- 暂停/恢复时主动唤醒控制器配方逻辑，避免退订休眠后无法复工
