### PR TITLE
修复 AE2 MAX_FAST 状态残留并完善批处理回退

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/api/recipe/BatchProcessing.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/recipe/BatchProcessing.java
@@ -186,7 +186,11 @@ public final class BatchProcessing {
         int maxCycles = timeLimit / recipe.duration;
         long realParallels = Math.max(1, IGTRecipe.of(recipe).getRealParallels());
         maxCycles = (int) Math.min(maxCycles, Long.MAX_VALUE / realParallels);
-        if (maxCycles <= 0) return new BatchSizeDecision(0, TIME_LIMIT_REJECTED, maxCycles, maxCycles);
+        if (maxCycles <= 0) {
+            // A short batch window must fall back to one normal cycle; rejecting the recipe
+            // here would stop a machine solely because batching is enabled.
+            return new BatchSizeDecision(1, TIME_LIMIT_FALLBACK_SINGLE_CYCLE, maxCycles, 0);
+        }
         if (maxCycles == 1) return new BatchSizeDecision(1, TIME_LIMIT_SINGLE_CYCLE, maxCycles, maxCycles);
 
         int amountLimitedCycles = limitByLongAmounts(recipe, maxCycles);

--- a/src/main/java/org/gtlcore/gtlcore/api/recipe/BatchProcessingDecisionLogger.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/recipe/BatchProcessingDecisionLogger.java
@@ -188,6 +188,10 @@ public final class BatchProcessingDecisionLogger {
                 "log.gtlcore.batch_processing.reason.time_limit_rejected",
                 "批处理时间上限不足以容纳一个配方周期",
                 "The batch time limit cannot fit one recipe cycle"),
+        TIME_LIMIT_FALLBACK_SINGLE_CYCLE(
+                "log.gtlcore.batch_processing.reason.time_limit_fallback_single_cycle",
+                "批处理时间窗小于单周期时长，回退为单周期执行",
+                "The batch window is shorter than one recipe cycle; falling back to one normal cycle"),
         TIME_LIMIT_SINGLE_CYCLE(
                 "log.gtlcore.batch_processing.reason.time_limit_single_cycle",
                 "批处理时间上限只能容纳一个配方周期",

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualHatchStockPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualHatchStockPartMachine.java
@@ -94,6 +94,7 @@ public class MEDualHatchStockPartMachine extends MEBusPartMachine implements IDa
     protected NotifiableFluidTank fluidTank;
 
     @DescSynced
+    @Persisted
     @Setter
     protected int page = 1;
 

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualInputHatchPartMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/multiblock/part/MEDualInputHatchPartMachine.java
@@ -49,6 +49,7 @@ public class MEDualInputHatchPartMachine extends MEInputBusPartMachine implement
     protected NotifiableFluidTank fluidTank;
 
     @DescSynced
+    @Persisted
     @Setter
     protected int page = 1;
 

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/compiled/MaxFastExecutor.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/crafting/compiled/MaxFastExecutor.java
@@ -112,6 +112,12 @@ public final class MaxFastExecutor {
         }
     }
 
+    public void resetAttemptState() {
+        this.preparedBoundaryCache.clear();
+        Arrays.fill(this.aggregatedPreparedBoundaries, null);
+        this.stack.clear();
+    }
+
     public void execute(ICraftingTreeNode root, CraftingSimulationState inv, long requestedAmount,
                         @Nullable KeyCounter containerItems, MaxFastMetrics metrics)
                                                                                      throws CraftBranchFailure,

--- a/src/main/java/org/gtlcore/gtlcore/mixin/ae2/crafting/CraftingCalculationMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/ae2/crafting/CraftingCalculationMixin.java
@@ -78,6 +78,9 @@ public abstract class CraftingCalculationMixin implements ICraftingCalculation {
     private NetworkCraftingSimulationState networkInv;
     @Shadow(remap = false)
     @Final
+    private CraftingTreeNode tree;
+    @Shadow(remap = false)
+    @Final
     private ICraftingSimulationRequester simRequester;
     @Shadow(remap = false)
     @Final
@@ -463,8 +466,11 @@ public abstract class CraftingCalculationMixin implements ICraftingCalculation {
     }
 
     @Inject(method = "runCraftAttempt", at = @At("HEAD"), remap = false)
-    private void gTLCore$beginMaxFastAttempt(boolean simulate, long amount,
-                                             CallbackInfoReturnable<CraftingPlan> cir) {
+    private void gTLCore$beginCraftAttempt(boolean simulate, long amount,
+                                           CallbackInfoReturnable<CraftingPlan> cir) {
+        if (this.gTLCore$calculationMode != AE2CalculationMode.LEGACY) {
+            ((ICraftingTreeNode) this.tree).gtlcore$resetFastState();
+        }
         if (this.gTLCore$calculationMode == AE2CalculationMode.MAX_FAST) {
             this.gTLCore$maxFastMetrics.beginAttempt(amount, simulate);
         }

--- a/src/main/java/org/gtlcore/gtlcore/mixin/ae2/crafting/CraftingTreeNodeMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/ae2/crafting/CraftingTreeNodeMixin.java
@@ -1076,11 +1076,33 @@ public abstract class CraftingTreeNodeMixin implements ICraftingTreeNode {
     @Override
     @Unique
     public void gtlcore$resetFastState() {
-        if (this.nodes == null) {
-            return;
+        if (this.nodes != null) {
+            for (CraftingTreeProcess node : this.nodes) {
+                ((ICraftingTreeProcess) node).gtlcore$resetFastState();
+            }
         }
-        for (CraftingTreeProcess node : this.nodes) {
-            ((ICraftingTreeProcess) node).gtlcore$resetFastState();
+        if (this.gTLCore$maxFastExecutor != null) {
+            this.gTLCore$maxFastExecutor.resetAttemptState();
+        }
+        if (this.gTLCore$maxFastCandidateGraphRoots != null) {
+            for (ICraftingTreeNode candidateRoot : this.gTLCore$maxFastCandidateGraphRoots) {
+                if (candidateRoot != null) {
+                    candidateRoot.gtlcore$resetFastState();
+                }
+            }
+        }
+        if (this.gTLCore$maxFastCandidateGraphExecutors != null) {
+            for (MaxFastExecutor candidateExecutor : this.gTLCore$maxFastCandidateGraphExecutors) {
+                if (candidateExecutor != null) {
+                    candidateExecutor.resetAttemptState();
+                }
+            }
+        }
+        if (this.gTLCore$maxFastCycleCandidateGraphRoot != null) {
+            this.gTLCore$maxFastCycleCandidateGraphRoot.gtlcore$resetFastState();
+        }
+        if (this.gTLCore$maxFastCycleCandidateGraphExecutor != null) {
+            this.gTLCore$maxFastCycleCandidateGraphExecutor.resetAttemptState();
         }
     }
 

--- a/src/main/resources/assets/gtlcore/lang/en_us.json
+++ b/src/main/resources/assets/gtlcore/lang/en_us.json
@@ -673,6 +673,7 @@
   "log.gtlcore.batch_processing.reason.not_recipe_logic_machine": "The machine does not implement the recipe-logic interface",
   "log.gtlcore.batch_processing.reason.non_positive_duration": "The recipe duration is zero or negative, so only one cycle can run",
   "log.gtlcore.batch_processing.reason.time_limit_rejected": "The batch time limit cannot fit one recipe cycle",
+  "log.gtlcore.batch_processing.reason.time_limit_fallback_single_cycle": "The batch window is shorter than one recipe cycle; falling back to one normal cycle",
   "log.gtlcore.batch_processing.reason.time_limit_single_cycle": "The batch time limit can fit only one recipe cycle",
   "log.gtlcore.batch_processing.reason.amount_overflow": "An item or fluid amount is invalid or exceeds long capacity, so batching was aborted",
   "log.gtlcore.batch_processing.reason.amount_limit_single_cycle": "Item or fluid amount limits allow only one recipe cycle",

--- a/src/main/resources/assets/gtlcore/lang/zh_cn.json
+++ b/src/main/resources/assets/gtlcore/lang/zh_cn.json
@@ -673,6 +673,7 @@
   "log.gtlcore.batch_processing.reason.not_recipe_logic_machine": "机器未实现配方逻辑接口",
   "log.gtlcore.batch_processing.reason.non_positive_duration": "配方时长小于或等于零，只能执行一个周期",
   "log.gtlcore.batch_processing.reason.time_limit_rejected": "批处理时间上限不足以容纳一个配方周期",
+  "log.gtlcore.batch_processing.reason.time_limit_fallback_single_cycle": "批处理时间窗小于单周期时长，回退为单周期执行",
   "log.gtlcore.batch_processing.reason.time_limit_single_cycle": "批处理时间上限只能容纳一个配方周期",
   "log.gtlcore.batch_processing.reason.amount_overflow": "配方物品或流体数量无效或总量溢出 long 容量，批处理被中止",
   "log.gtlcore.batch_processing.reason.amount_limit_single_cycle": "物品或流体总量上限只允许一个配方周期",


### PR DESCRIPTION
## 摘要

- 在每次非传统模式的合成尝试开始时，重置 MAX_FAST 执行器和候选图状态。
- 清理已准备边界缓存与执行栈，避免复用合成状态。
- 当批处理时间窗短于配方时长时，回退为执行一个普通配方周期。
- 持久化双仓室部件的分页状态，使其在重新加载后保持不变。
- 为单周期回退决策补充中英文日志文本。