### PR TITLE
bug修复

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/client/ae2/wireless/MEChamberManagerTerminalScreen.java
+++ b/src/main/java/org/gtlcore/gtlcore/client/ae2/wireless/MEChamberManagerTerminalScreen.java
@@ -408,15 +408,21 @@ public final class MEChamberManagerTerminalScreen extends AEBaseScreen<MEChamber
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (keyCode == GLFW.GLFW_KEY_E || keyCode == minecraft.options.keyInventory.getKey().getValue()) {
-            return true;
-        }
         if (configuratorOverlay.isOpen()) {
             if (keyCode == GLFW.GLFW_KEY_ESCAPE) {
                 configuratorOverlay.close();
                 return true;
             }
             return configuratorOverlay.keyPressed(keyCode, scanCode, modifiers);
+        }
+        boolean inventoryKey = keyCode == GLFW.GLFW_KEY_E ||
+                keyCode == minecraft.options.keyInventory.getKey().getValue();
+        if (inventoryKey) {
+            // A focused text field still receives the typed character through charTyped.
+            if (!isTextFieldFocused()) {
+                onClose();
+            }
+            return true;
         }
         if (keyCode == GLFW.GLFW_KEY_ESCAPE) {
             onClose();
@@ -432,6 +438,10 @@ public final class MEChamberManagerTerminalScreen extends AEBaseScreen<MEChamber
             return true;
         }
         return super.keyPressed(keyCode, scanCode, modifiers);
+    }
+
+    private boolean isTextFieldFocused() {
+        return searchField.isFocused() || amountField.isFocused() || priorityField.isFocused();
     }
 
     @Override

--- a/src/main/java/org/gtlcore/gtlcore/client/gui/PatternModifierClientState.java
+++ b/src/main/java/org/gtlcore/gtlcore/client/gui/PatternModifierClientState.java
@@ -1,0 +1,70 @@
+package org.gtlcore.gtlcore.client.gui;
+
+import org.gtlcore.gtlcore.GTLCore;
+
+import net.minecraftforge.fml.loading.FMLPaths;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Remembers the pattern modifier screen's scope and insert/delete toggle across screens and restarts.
+ * Purely client-side; stored in config/gtlcore/pattern_modifier.json.
+ */
+public final class PatternModifierClientState {
+
+    private static final Gson GSON = new GsonBuilder().create();
+    private static final Path FILE = FMLPaths.CONFIGDIR.get().resolve("gtlcore").resolve("pattern_modifier.json");
+    private static PatternModifierClientState instance;
+
+    public int scope;
+    public boolean insertDelete;
+
+    public static synchronized PatternModifierClientState get() {
+        if (instance == null) {
+            instance = load();
+        }
+        return instance;
+    }
+
+    public synchronized void save() {
+        try {
+            Files.createDirectories(FILE.getParent());
+            JsonObject json = new JsonObject();
+            json.addProperty("scope", scope);
+            json.addProperty("insertDelete", insertDelete);
+            try (Writer writer = Files.newBufferedWriter(FILE)) {
+                GSON.toJson(json, writer);
+            }
+        } catch (IOException e) {
+            GTLCore.LOGGER.warn("Failed to save pattern modifier client state", e);
+        }
+    }
+
+    private static PatternModifierClientState load() {
+        PatternModifierClientState state = new PatternModifierClientState();
+        if (!Files.isRegularFile(FILE)) {
+            return state;
+        }
+        try (Reader reader = Files.newBufferedReader(FILE)) {
+            JsonObject json = JsonParser.parseReader(reader).getAsJsonObject();
+            if (json.has("scope")) {
+                state.scope = Math.floorMod(json.get("scope").getAsInt(), 3);
+            }
+            if (json.has("insertDelete")) {
+                state.insertDelete = json.get("insertDelete").getAsBoolean();
+            }
+        } catch (Exception e) {
+            GTLCore.LOGGER.warn("Failed to load pattern modifier client state, using defaults", e);
+        }
+        return state;
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/common/machine/VirtualIngredientSupplyMachine.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/machine/VirtualIngredientSupplyMachine.java
@@ -194,6 +194,14 @@ public class VirtualIngredientSupplyMachine extends MetaMachine
     // ==================== Persistence ====================
 
     @Override
+    public void onRotated(@NotNull Direction oldFacing, @NotNull Direction newFacing) {
+        super.onRotated(oldFacing, newFacing);
+        if (!getHolder().self().getPersistentData().getBoolean("isAllFacing")) {
+            getMainNode().setExposedOnSides(EnumSet.of(newFacing));
+        }
+    }
+
+    @Override
     public void loadCustomPersistedData(@NotNull CompoundTag tag) {
         super.loadCustomPersistedData(tag);
         if (tag.getCompound("ForgeData").getBoolean("isAllFacing")) {

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/pattern/PatternQuickUploadRecipeTypeResolver.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/pattern/PatternQuickUploadRecipeTypeResolver.java
@@ -161,11 +161,40 @@ public final class PatternQuickUploadRecipeTypeResolver {
                 checkedRecipes,
                 matchedRecipes,
                 recipeTypeIds);
+        collapseSmallLargePairs(recipeTypeIds);
         if (recipeTypeIds.size() > 1) {
             GTLCore.LOGGER.debug("{} resolver rejected ambiguous GT recipe types {}", LOG_PREFIX, recipeTypeIds);
             return Set.of();
         }
         return recipeTypeIds;
+    }
+
+    /**
+     * Large variants (e.g. {@code gtceu:large_chemical_reactor}) auto-copy every recipe of their small map, so a
+     * matching pattern always reports both. The pair names the same recipe set: keep the small id and let target
+     * matching fall back through {@code getSmallRecipeMap}.
+     */
+    private static void collapseSmallLargePairs(Set<ResourceLocation> recipeTypeIds) {
+        Set<ResourceLocation> redundantIds = new LinkedHashSet<>();
+        for (ResourceLocation id : recipeTypeIds) {
+            GTRecipeType smallType = GTRegistries.RECIPE_TYPES.get(id);
+            if (smallType == null) {
+                continue;
+            }
+            for (ResourceLocation otherId : recipeTypeIds) {
+                if (otherId.equals(id)) {
+                    continue;
+                }
+                GTRecipeType otherType = GTRegistries.RECIPE_TYPES.get(otherId);
+                if (otherType != null && otherType.getSmallRecipeMap() == smallType) {
+                    redundantIds.add(otherId);
+                }
+            }
+        }
+        if (!redundantIds.isEmpty()) {
+            GTLCore.LOGGER.debug("{} resolver collapsed small/large recipe type pairs, dropped {}", LOG_PREFIX, redundantIds);
+            recipeTypeIds.removeAll(redundantIds);
+        }
     }
 
     private record PatternSignature(Object2LongOpenHashMap<AEItemKey> inputItems,

--- a/src/main/java/org/gtlcore/gtlcore/integration/ae2/pattern/PatternQuickUploadService.java
+++ b/src/main/java/org/gtlcore/gtlcore/integration/ae2/pattern/PatternQuickUploadService.java
@@ -497,7 +497,7 @@ public final class PatternQuickUploadService {
             if (recipeType.registryName == null) {
                 continue;
             }
-            if (!recipeTypeIds.contains(recipeType.registryName)) {
+            if (!recipeTypeMatches(recipeType, recipeTypeIds)) {
                 continue;
             }
             TargetKey key = new TargetKey(levelKey, buffer.getPos(), recipeType.registryName);
@@ -635,6 +635,19 @@ public final class PatternQuickUploadService {
                         terminalGroup.name().getString());
             }
         }
+    }
+
+    /**
+     * Large variants such as {@code gtceu:large_chemical_reactor} copy every recipe of their small map, so a pattern
+     * resolved against the small type also belongs on machines of the large type.
+     */
+    private static boolean recipeTypeMatches(GTRecipeType machineRecipeType, Set<ResourceLocation> recipeTypeIds) {
+        if (recipeTypeIds.contains(machineRecipeType.registryName)) {
+            return true;
+        }
+        GTRecipeType smallRecipeMap = machineRecipeType.getSmallRecipeMap();
+        return smallRecipeMap != null && smallRecipeMap.registryName != null &&
+                recipeTypeIds.contains(smallRecipeMap.registryName);
     }
 
     private static boolean hasFormedController(Iterable<IMultiController> controllers) {

--- a/src/main/java/org/gtlcore/gtlcore/mixin/extendedae/GuiPatternModifierMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/extendedae/GuiPatternModifierMixin.java
@@ -3,6 +3,7 @@ package org.gtlcore.gtlcore.mixin.extendedae;
 import org.gtlcore.gtlcore.client.gui.IPatternModifierScreen;
 import org.gtlcore.gtlcore.client.gui.ModifyIcon;
 import org.gtlcore.gtlcore.client.gui.ModifyIconButton;
+import org.gtlcore.gtlcore.client.gui.PatternModifierClientState;
 import org.gtlcore.gtlcore.client.gui.SetReplaceAmountScreen;
 
 import net.minecraft.client.gui.components.Button;
@@ -124,6 +125,9 @@ public abstract class GuiPatternModifierMixin extends AEBaseScreen<ContainerPatt
 
     @Unique
     private void gtlcore$createButtons() {
+        PatternModifierClientState state = PatternModifierClientState.get();
+        this.gtlcore$scope = state.scope;
+        this.gtlcore$insertDelete = state.insertDelete;
         this.gtlcore$scaleButtons = new ArrayList<>();
         this.gtlcore$scaleButtons.add(gtlcore$createScaleButton(2, false, ModifyIcon.MULTIPLY_2,
                 Component.translatable("gui.gtlcore.pattern_recipe_multiply_2"),
@@ -145,6 +149,8 @@ public abstract class GuiPatternModifierMixin extends AEBaseScreen<ContainerPatt
                 Component.translatable("tooltip.gtlcore.pattern_materials_divide_5")));
         this.gtlcore$scopeButton = Button.builder(Component.empty(), b -> {
             this.gtlcore$scope = (this.gtlcore$scope + 1) % 3;
+            state.scope = this.gtlcore$scope;
+            state.save();
             gtlcore$updateScopeButton();
         }).size(28, 18)
                 .tooltip(Tooltip.create(Component.translatable("tooltip.gtlcore.pattern_modify_scope")))
@@ -155,6 +161,8 @@ public abstract class GuiPatternModifierMixin extends AEBaseScreen<ContainerPatt
                 Component.translatable("tooltip.gtlcore.pattern_modifier.swap_replace"));
         this.gtlcore$insertDeleteButton = new IconButton(b -> {
             this.gtlcore$insertDelete = !this.gtlcore$insertDelete;
+            state.insertDelete = this.gtlcore$insertDelete;
+            state.save();
         }) {
 
             @Override


### PR DESCRIPTION
四个小问题的修复与优化：
 - 修复了虚拟原料供应器扳手旋转时频道面不跟随；
 - ME仓室管理终端现在支持E键退出（文本框聚焦时可正常输入e）；
 - 样板修改器缩放范围与插入删除设置持久化到客户端配置；
 - 化学反应釜与大型化学反应釜样板现在可互相上传（smallRecipeMap配对折叠与回退匹配）