### PR TITLE
perf: 优化世界固定层结构匹配并修复 Jade 成型状态

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/api/pattern/PreviewMatcherTiming.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/pattern/PreviewMatcherTiming.java
@@ -4,7 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 
 import java.util.Locale;
 
-/** Explicit preview scope: real-world structure checks keep the existing search path. */
+/** Explicit preview scope: incremental search remains isolated from real-world structure checks. */
 public final class PreviewMatcherTiming implements AutoCloseable {
 
     private static final ThreadLocal<PreviewMatcherTiming> ACTIVE = new ThreadLocal<>();

--- a/src/main/java/org/gtlcore/gtlcore/api/pattern/WorldPatternMatcher.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/pattern/WorldPatternMatcher.java
@@ -1,0 +1,18 @@
+package org.gtlcore.gtlcore.api.pattern;
+
+import com.gregtechceu.gtceu.api.pattern.MultiblockState;
+
+import net.minecraft.server.level.ServerLevel;
+
+/** Selects the world fast path independently of preview scopes and diagnostic logging. */
+public final class WorldPatternMatcher {
+
+    private static final boolean FIXED_ENABLED = !Boolean.getBoolean("gtlcore.world.disableFixedMatcher");
+
+    private WorldPatternMatcher() {}
+
+    /** The caller must also verify that every aisle has an exact, valid repetition count. */
+    public static boolean useFixedLayout(MultiblockState state) {
+        return FIXED_ENABLED && state.world instanceof ServerLevel;
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/api/pattern/WorldPatternTiming.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/pattern/WorldPatternTiming.java
@@ -1,0 +1,215 @@
+package org.gtlcore.gtlcore.api.pattern;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
+import com.gregtechceu.gtceu.api.pattern.MultiblockState;
+
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Optional world matcher diagnostics, enabled with {@code -Dgtlcore.worldPatternTimer.enabled=true}.
+ * Never opens a preview scope or selects a different matcher.
+ */
+public final class WorldPatternTiming implements AutoCloseable {
+
+    private static final boolean ENABLED = Boolean.getBoolean("gtlcore.worldPatternTimer.enabled") &&
+            !Boolean.getBoolean("gtlcore.worldPatternTimer.disabled");
+    private static final String FOCUS = System.getProperty("gtlcore.worldPatternTimer.focus", "subspace");
+    private static final long SLOW_NANOS = 100_000_000L;
+    private static final AtomicLong SEQUENCE = new AtomicLong();
+    private static final ThreadLocal<WorldPatternTiming> CHECK = new ThreadLocal<>();
+    private static final ThreadLocal<Matcher> MATCHER = new ThreadLocal<>();
+
+    private final WorldPatternTiming previous;
+    private final MultiblockState state;
+    private final long sequence = SEQUENCE.incrementAndGet();
+    private final String identity;
+    private final String dimension;
+    private final String position;
+    private final String thread = Thread.currentThread().getName();
+    private final boolean serverThread;
+    private final String source;
+    private final boolean focused;
+    private final long start;
+    private long lockNanos;
+    private String lockAcquired = "not_requested";
+    private long matcherNanos;
+    private int matcherCalls;
+    private int unloadedAttempts;
+    private String firstFailureError = "none";
+    private String firstFailurePos = "none";
+    private String firstFailureFacing = "none";
+    private boolean firstFailureFlipped;
+    private int startAttempts;
+    private long slices;
+    private long replays;
+    private long replayedSlices;
+    private String algorithm = "none";
+    private String lastFacing = "none";
+    private boolean lastFlipped;
+    private String result = "exception";
+
+    private WorldPatternTiming(MultiblockState state, IMultiController controller, String source) {
+        this.state = state;
+        this.source = source;
+        identity = controller == null ? "unknown" : controller.self().getDefinition().getId().toString();
+        ServerLevel level = (ServerLevel) state.world;
+        dimension = level.dimension().location().toString();
+        position = state.controllerPos.getX() + "," + state.controllerPos.getY() + "," + state.controllerPos.getZ();
+        serverThread = level.getServer().isSameThread();
+        focused = FOCUS.isEmpty() || identity.contains(FOCUS);
+        previous = CHECK.get();
+        CHECK.set(this);
+        if (focused) {
+            GTCEu.LOGGER.info("[World Pattern] START timer_version=2 seq={} id={} dim={} pos={} " +
+                    "thread=\"{}\" server_thread={} source={}",
+                    sequence, identity, dimension, position, thread, serverThread, source);
+        }
+        // Exclude START log formatting/output from the reported check time.
+        start = System.nanoTime();
+    }
+
+    public static WorldPatternTiming beginCheck(IMultiController controller, String source) {
+        if (!ENABLED || !(controller.self().getLevel() instanceof ServerLevel)) return null;
+        return new WorldPatternTiming(controller.getMultiblockState(), controller, source);
+    }
+
+    public static Matcher beginMatcher(MultiblockState state, Direction facing, boolean flipped) {
+        if (!ENABLED || !(state.world instanceof ServerLevel)) return null;
+        WorldPatternTiming owner = CHECK.get();
+        boolean standalone = owner == null || owner.state != state;
+        if (standalone) owner = new WorldPatternTiming(state, state.lastController, "direct_orientation");
+        return new Matcher(owner, state, facing, flipped, standalone);
+    }
+
+    public void lockResult(long lockStart, boolean acquired) {
+        lockNanos += System.nanoTime() - lockStart;
+        lockAcquired = Boolean.toString(acquired);
+    }
+
+    public void result(boolean matched) {
+        result = "false".equals(lockAcquired) ? "lock_busy" : Boolean.toString(matched);
+    }
+
+    public static void attempt(MultiblockState state, String algorithm) {
+        if (!ENABLED) return;
+        Matcher matcher = MATCHER.get();
+        if (matcher != null && matcher.state == state) {
+            matcher.owner.algorithm = algorithm;
+            matcher.owner.startAttempts++;
+        }
+    }
+
+    public static void slice(MultiblockState state) {
+        if (!ENABLED) return;
+        Matcher matcher = MATCHER.get();
+        if (matcher != null && matcher.state == state) matcher.owner.slices++;
+    }
+
+    public static void replay(MultiblockState state) {
+        if (!ENABLED) return;
+        Matcher matcher = MATCHER.get();
+        if (matcher != null && matcher.state == state) matcher.owner.replays++;
+    }
+
+    public static void replayedSlice(MultiblockState state) {
+        if (!ENABLED) return;
+        Matcher matcher = MATCHER.get();
+        if (matcher != null && matcher.state == state) matcher.owner.replayedSlices++;
+    }
+
+    @Override
+    public void close() {
+        long elapsed = System.nanoTime() - start;
+        if (previous == null) CHECK.remove();
+        else CHECK.set(previous);
+        // Keep incomplete small machines from printing every second. Focused checks always log.
+        if (focused || elapsed >= SLOW_NANOS || "true".equals(result) || "exception".equals(result)) {
+            GTCEu.LOGGER.info("[World Pattern] END timer_version=2 seq={} id={} dim={} pos={} " +
+                    "thread=\"{}\" server_thread={} source={} result={} lock_acquired={} " +
+                    "check_total_ms={} lock_wait_ms={} matcher_ms={} matcher_calls={} " +
+                    "algorithm={} start_attempts={} slice_calls={} prefix_replays={} replayed_slices={} " +
+                    "last_facing={} last_flipped={} unloaded={} unloaded_attempts={} " +
+                    "first_failure_error={} first_failure_pos={} first_failure_facing={} first_failure_flipped={}",
+                    sequence, identity, dimension, position, thread, serverThread, source, result, lockAcquired,
+                    millis(elapsed), millis(lockNanos), millis(matcherNanos), matcherCalls,
+                    algorithm, startAttempts, slices, replays, replayedSlices, lastFacing, lastFlipped,
+                    state.error == MultiblockState.UNLOAD_ERROR, unloadedAttempts,
+                    firstFailureError, firstFailurePos, firstFailureFacing, firstFailureFlipped);
+        }
+    }
+
+    private static String millis(long nanos) {
+        return String.format(Locale.ROOT, "%.3f", nanos / 1_000_000.0);
+    }
+
+    private static String lastVisitedPosition(MultiblockState state) {
+        try {
+            var pos = state.getPos();
+            return pos == null ? "unknown" : pos.getX() + "," + pos.getY() + "," + pos.getZ();
+        } catch (RuntimeException ignored) {
+            // GTCEu's getter dereferences its nullable position before the first update.
+            return "unknown";
+        }
+    }
+
+    public static final class Matcher implements AutoCloseable {
+
+        private final WorldPatternTiming owner;
+        private final MultiblockState state;
+        private final Matcher previous;
+        private final boolean standalone;
+        private final String facing;
+        private final boolean flipped;
+        private final long start = System.nanoTime();
+        private boolean matched;
+        private boolean completed;
+
+        private Matcher(WorldPatternTiming owner, MultiblockState state, Direction facing, boolean flipped,
+                        boolean standalone) {
+            this.owner = owner;
+            this.state = state;
+            this.standalone = standalone;
+            this.facing = facing.name();
+            this.flipped = flipped;
+            previous = MATCHER.get();
+            MATCHER.set(this);
+            owner.matcherCalls++;
+            owner.lastFacing = facing.name();
+            owner.lastFlipped = flipped;
+        }
+
+        public void result(boolean matched) {
+            this.matched = matched;
+            completed = true;
+        }
+
+        @Override
+        public void close() {
+            owner.matcherNanos += System.nanoTime() - start;
+            if (previous == null) MATCHER.remove();
+            else MATCHER.set(previous);
+            try {
+                // Snapshot each orientation's error before the outer GT wrapper retries a flip and clears it.
+                boolean unloaded = completed && state.error == MultiblockState.UNLOAD_ERROR;
+                if (unloaded) owner.unloadedAttempts++;
+                if ((!completed || !matched) && "none".equals(owner.firstFailureError)) {
+                    owner.firstFailureError = !completed ? "exception" : unloaded ? "unloaded" :
+                            state.error == null ? "predicate_rejected" : state.error.getClass().getSimpleName();
+                    owner.firstFailurePos = lastVisitedPosition(state);
+                    owner.firstFailureFacing = facing;
+                    owner.firstFailureFlipped = flipped;
+                }
+            } finally {
+                if (standalone) {
+                    if (completed) owner.result(matched);
+                    owner.close();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/MultiblockStructureProviderMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/MultiblockStructureProviderMixin.java
@@ -1,0 +1,28 @@
+package org.gtlcore.gtlcore.mixin.gtm;
+
+import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
+import com.gregtechceu.gtceu.integration.jade.provider.MultiblockStructureProvider;
+
+import net.minecraft.nbt.CompoundTag;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import snownee.jade.api.BlockAccessor;
+
+@Mixin(MultiblockStructureProvider.class)
+public abstract class MultiblockStructureProviderMixin {
+
+    @Inject(method = "appendServerData(Lnet/minecraft/nbt/CompoundTag;Lsnownee/jade/api/BlockAccessor;)V",
+            at = @At("TAIL"),
+            remap = false)
+    private void gtlcore$publishFormedState(CompoundTag tag, BlockAccessor accessor, CallbackInfo ci) {
+        if (accessor.getBlockEntity() instanceof MetaMachineBlockEntity blockEntity &&
+                blockEntity.getMetaMachine() instanceof IMultiController controller) {
+            // The matcher clears its working error repeatedly, even when the machine is still unformed.
+            tag.putBoolean("hasError", !controller.isFormed());
+        }
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/machine/MultiblockControllerMachineMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/machine/MultiblockControllerMachineMixin.java
@@ -1,5 +1,7 @@
 package org.gtlcore.gtlcore.mixin.gtm.api.machine;
 
+import org.gtlcore.gtlcore.api.pattern.WorldPatternTiming;
+
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
@@ -33,6 +35,39 @@ public abstract class MultiblockControllerMachineMixin extends MetaMachine imple
 
     public MultiblockControllerMachineMixin(IMachineBlockEntity holder) {
         super(holder);
+    }
+
+    // Diagnostic copies of the GTCEu 1.4.4 interface defaults. Keep lock/check/unlock order unchanged.
+    @Override
+    public boolean checkPatternWithLock() {
+        try (var timing = WorldPatternTiming.beginCheck(this, "lock")) {
+            Lock lock = getPatternLock();
+            long lockStart = timing == null ? 0L : System.nanoTime();
+            lock.lock();
+            if (timing != null) timing.lockResult(lockStart, true);
+            boolean matched = checkPattern();
+            lock.unlock();
+            if (timing != null) timing.result(matched);
+            return matched;
+        }
+    }
+
+    @Override
+    public boolean checkPatternWithTryLock() {
+        try (var timing = WorldPatternTiming.beginCheck(this, "try_lock")) {
+            Lock lock = getPatternLock();
+            long lockStart = timing == null ? 0L : System.nanoTime();
+            boolean acquired = lock.tryLock();
+            if (timing != null) timing.lockResult(lockStart, acquired);
+            if (acquired) {
+                boolean matched = checkPattern();
+                lock.unlock();
+                if (timing != null) timing.result(matched);
+                return matched;
+            }
+            if (timing != null) timing.result(false);
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/pattern/BlockPatternMixin.java
+++ b/src/main/java/org/gtlcore/gtlcore/mixin/gtm/api/pattern/BlockPatternMixin.java
@@ -4,6 +4,8 @@ import org.gtlcore.gtlcore.api.pattern.AdvancedBlockPattern;
 import org.gtlcore.gtlcore.api.pattern.FixedPatternLayout;
 import org.gtlcore.gtlcore.api.pattern.PatternLayoutSearch;
 import org.gtlcore.gtlcore.api.pattern.PreviewMatcherTiming;
+import org.gtlcore.gtlcore.api.pattern.WorldPatternMatcher;
+import org.gtlcore.gtlcore.api.pattern.WorldPatternTiming;
 import org.gtlcore.gtlcore.mixin.gtm.api.machine.IMultiblockStateInvoker;
 
 import com.gregtechceu.gtceu.api.block.ActiveBlock;
@@ -72,8 +74,19 @@ public abstract class BlockPatternMixin {
      */
     @Overwrite(remap = false)
     public boolean checkPatternAt(MultiblockState worldState, BlockPos centerPos, Direction frontFacing, Direction upwardsFacing, boolean isFlipped, boolean savePredicate) {
-        int[] fixedRepetitions = PreviewMatcherTiming.useFixedLayout(worldState) ?
-                FixedPatternLayout.repetitions(this.aisleRepetitions) : null;
+        try (var timing = WorldPatternTiming.beginMatcher(worldState, frontFacing, isFlipped)) {
+            boolean matched = gtlcore$checkPatternAt(worldState, centerPos, frontFacing, upwardsFacing, isFlipped, savePredicate);
+            if (timing != null) timing.result(matched);
+            return matched;
+        }
+    }
+
+    @Unique
+    private boolean gtlcore$checkPatternAt(MultiblockState worldState, BlockPos centerPos, Direction frontFacing,
+                                           Direction upwardsFacing, boolean isFlipped, boolean savePredicate) {
+        int[] fixedRepetitions = (PreviewMatcherTiming.useFixedLayout(worldState) ||
+                WorldPatternMatcher.useFixedLayout(worldState)) ?
+                        FixedPatternLayout.repetitions(this.aisleRepetitions) : null;
         if (fixedRepetitions != null && fixedRepetitions.length != this.fingerLength) fixedRepetitions = null;
         boolean incremental = fixedRepetitions == null && PreviewMatcherTiming.useIncrementalSearch(worldState) &&
                 PatternLayoutSearch.supports(this.aisleRepetitions, this.fingerLength);
@@ -82,6 +95,7 @@ public abstract class BlockPatternMixin {
         int maxStartZ = -this.centerOffset[3];
         for (int startZ = minStartZ; startZ <= maxStartZ; startZ++) {
             Arrays.fill(matchedRepetitions, 0);
+            WorldPatternTiming.attempt(worldState, fixedRepetitions != null ? "fixed_linear" : incremental ? "incremental" : "legacy_replay");
             if (incremental) PreviewMatcherTiming.incrementalAttempt();
             else PreviewMatcherTiming.attempt(fixedRepetitions != null);
             boolean matched;
@@ -163,11 +177,13 @@ public abstract class BlockPatternMixin {
                                          Direction upwardsFacing, boolean isFlipped, boolean savePredicate, int startZ,
                                          int lastAisle, int[] repetitions) {
         PreviewMatcherTiming.replay();
+        WorldPatternTiming.replay(worldState);
         ((IMultiblockStateInvoker) worldState).cleanState();
         int z = startZ;
         for (int aisle = 0; aisle <= lastAisle; aisle++) {
             for (int repeat = 0; repeat < repetitions[aisle]; repeat++, z++) {
                 PreviewMatcherTiming.replayedSlice();
+                WorldPatternTiming.replayedSlice(worldState);
                 if (!gtlcore$matchSlice(worldState, centerPos, frontFacing, upwardsFacing, isFlipped, savePredicate,
                         aisle, z)) {
                     return false;
@@ -182,6 +198,7 @@ public abstract class BlockPatternMixin {
                                        Direction upwardsFacing, boolean isFlipped, boolean savePredicate, int aisle,
                                        int z) {
         PreviewMatcherTiming.slice();
+        WorldPatternTiming.slice(worldState);
         Map<SimplePredicate, Integer> layerCount = worldState.getLayerCount();
         layerCount.clear();
         PatternMatchContext matchContext = worldState.getMatchContext();

--- a/src/main/resources/gtlcore.mixin.json
+++ b/src/main/resources/gtlcore.mixin.json
@@ -141,6 +141,7 @@
     "gtm.MultiblockInfoDisplayMixin",
     "gtm.MultiblockInfoEmiRecipeMixin",
     "gtm.OverclockingLogicMixin",
+    "gtm.MultiblockStructureProviderMixin",
     "gtm.RecipeLogicProviderMixin",
     "gtm.RecipeOutputProviderMixin",
     "gtm.RockBreakerConditionMixin",


### PR DESCRIPTION
世界内的多方块结构检查原本使用递归搜索和前缀重放。即使所有结构层的重复次数都已固定，检查后续层时仍会清空匹配状态，重新检查此前的完整前缀，导致大型结构产生大量重复工作。

本次将固定重复次数结构的线性匹配路径用于服务端世界检查。只有所有层均满足最小重复次数等于最大重复次数时才启用；包含可变重复层的世界结构继续使用原有搜索算法。


同时修复 Jade 成型提示闪烁：原实现根据匹配器的临时错误状态判断结构是否成型，后台检查清空错误时可能提前显示“已成型”。现在改为读取控制器实际的 `isFormed()` 状态。

### 性能对比

在兼容 GTL Additions 的测试版本中，对同一个亚空间航道枢纽工业集群进行世界内检查。以下为成功匹配的实测记录：

| 指标 | 原算法 | 优化后 |
| --- | ---: | ---: |
| matcher 耗时 | 44,615.991 ms | 337.793 ms |
| 结构层检查次数 | 37,674 | 273 |
| 前缀重放次数 | 273 | 0 |
| 被重放的层数 | 37,401 | 0 |

本轮成功匹配耗时减少约 **99.24%**，约为原来的 **132 倍速度**。另一轮优化后的成功匹配耗时为 **434.464 ms**。

计时范围为结构匹配本身，不包含等待区块加载或后续成型回调。检查运行于 GTCEu 多方块后台线程，以上耗时不能直接等同于主线程卡顿时间。结果为单次记录对比，并非多轮平均基准。

### 诊断与验证

添加 JVM 参数即可启用计时器：

`-Dgtlcore.worldPatternTimer.enabled=true`

需要在同一版本中对比原算法时，可添加：

`-Dgtlcore.world.disableFixedMatcher=true`

